### PR TITLE
Fix initialization failure in deployed version

### DIFF
--- a/src/services/database.service.ts
+++ b/src/services/database.service.ts
@@ -257,10 +257,13 @@ export class DatabaseService {
    * @throws {DatabaseError} If query fails
    */
   public getSchemaVersion(): number | null {
-    this.ensureReady();
+    // During initialization, we may not be in READY state yet, so just check if db exists
+    if (!this.db) {
+      throw new DatabaseError('Database instance not available');
+    }
 
     try {
-      const result = this.db!.exec(QUERY_SCHEMA_VERSION);
+      const result = this.db.exec(QUERY_SCHEMA_VERSION);
 
       if (result.length === 0 || !result[0] || result[0].values.length === 0) {
         return null;


### PR DESCRIPTION
Fixed DatabaseError during initialization when loading existing database from IndexedDB. The issue was a circular call chain:
- initialize() sets state to INITIALIZING
- validateSchemaVersion() calls getSchemaVersion()
- getSchemaVersion() calls ensureReady()
- ensureReady() throws error because state is not READY yet

Changed getSchemaVersion() to check if database instance exists rather than requiring full READY state, since it's legitimately called during initialization before state transitions to READY.

Closes: Deployment initialization error on cached databases

🤖 Generated with Claude Code (https://claude.com/claude-code)