### PR TITLE
Self-contained HTML timeline artifact (export)

### DIFF
--- a/ref/html-artifact-export.md
+++ b/ref/html-artifact-export.md
@@ -1,0 +1,149 @@
+# SwimLanes HTML Timeline Artifact — Export Plan
+
+**Status:** Proposed (planning only — no implementation yet)
+**Owner:** @mr-jafner
+**Last Updated:** 2026-06-25
+**Related:** `ref/roadmap.md` (Stage 3 / Export), `src/services/timeline.service.ts`
+
+---
+
+## Summary
+
+Introduce a **standalone, self-contained HTML timeline artifact** as a first-class
+output of SwimLanes — conceptually equivalent to Plotly's `fig.write_html()`, but
+purpose-built for swim-lane timelines and **hand-rolled in SVG**.
+
+The artifact is a single `.html` file with the dataset **inlined as JSON** plus a
+small embedded renderer. It opens in any browser, offline, with no app, no server,
+and no `sql.js`/React runtime. It is the thing a user hands to a stakeholder who
+will never open the SwimLanes app.
+
+This **does not invalidate prior scope.** It re-frames the relationship between the
+two halves of the product (see Positioning below).
+
+---
+
+## Positioning: author-first, artifact-as-hero-output
+
+SwimLanes has two halves that are easy to mistake as competing:
+
+- **Authoring + branching + scenario comparison** = the *value-creation layer* (the
+  moat). This is the differentiated work and the reason any output is worth making.
+- **The static HTML report** = the *distribution layer* (the hero output). It is how
+  the work travels to people who never open the app.
+
+These are not in conflict. The analogy is Jupyter (notebook authoring → exported
+HTML) or Figma (editor → shared prototype link): the editor is the moat, the export
+is how value reaches stakeholders, and export being first-class is what makes the
+authoring worth doing.
+
+**Decision:** Position the app as a focused **scenario-authoring tool** and treat the
+**multi-scenario HTML report as the flagship output.** The app should not get
+*thinner*; it should get *better at scenarios specifically* (fast branch creation,
+side-by-side diff, what-if). The report is the proof that the scenario work paid off.
+
+### Why this artifact is differentiated (not just another Gantt export)
+
+The branching feature is what makes the artifact unique. A static HTML file that lets
+a stakeholder **toggle between baked-in scenarios offline** — "here's the plan; flip
+to the aggressive vs. conservative timeline" — is something Plotly export, MS Project,
+or a screenshot fundamentally cannot do. Branching is the report's killer feature, not
+a competitor to it.
+
+**Implication:** multi-scenario-in-one-file is an explicit design goal **from day one**,
+even though v1 ships single-branch. It shapes the embedded HTML/JSON structure
+(embed data for N branches; JS toggles between them). With hand-rolled SVG this is
+cheap — we own all the geometry, so we emit one SVG per branch and show/hide.
+
+---
+
+## Renderer decision: hand-rolled SVG
+
+Chosen over Plotly and vis-timeline.
+
+| Option | Verdict |
+| --- | --- |
+| **Hand-rolled SVG** ✅ | Smallest file, zero runtime deps, full control of the swim-lane / milestone-diamond / release-bar visual language we already defined. Reuses `timeline.service.ts` view model. Multi-scenario toggle is trivial. Most build effort — accepted. |
+| vis-timeline | Good domain fit, native grouping, but adds a dependency and cedes control of the visual language. |
+| Plotly `write_html` | Fastest to prototype but heavy (~3 MB) and Gantt is a hack on top of bar charts; swim lanes / diamonds get awkward. |
+
+The exporter is a **consumer of `timeline.service.ts`'s view model**, so the layout
+math serves both the in-app canvas and the artifact. This is leverage, not duplication.
+
+---
+
+## Resolved design decisions
+
+1. **Read-only artifact (v1).** The exported HTML is a clean, trustworthy snapshot.
+   No "edit in the HTML and re-import" loop in v1 — it muddies what the artifact *is*
+   and would bloat the embedded JS. Revisit only if there's clear demand.
+2. **Data-baked = data-exposed.** The file contains the full selected dataset inline.
+   This fits the local-first model, but "share the file" = "share all baked data."
+   Mitigation: the exporter takes an explicit **branch / filter selection** so the user
+   only bakes what they mean to share.
+3. **Moat stays in authoring.** Long-term investment goes into scenario tooling, not
+   into making the app a general PM tool.
+
+---
+
+## Roadmap (v1 → v3)
+
+### v1 — Single-branch SVG report
+- New `src/services/export.service.ts`.
+- Input: a branch id + optional type/project filters (reuse existing filter logic).
+- Build the view model via `timeline.service.ts`.
+- Emit a single self-contained `.html`: inlined JSON dataset + embedded SVG renderer
+  + minimal CSS, generated string-side (no React in the output).
+- Renders swim lanes, task/release/meeting bars, milestone diamonds, time axis —
+  matching the app's visual encoding (task=blue, milestone=green, release=orange,
+  meeting=purple).
+- Trigger from the UI ("Export timeline → HTML") producing a browser download.
+- **Structure the embedded payload for N branches now**, even though only one is
+  populated, so v2 is additive.
+
+### v2 — Multi-scenario toggle baked in
+- Bake multiple branches into one file; embed a lightweight branch/scenario switcher
+  (vanilla JS show/hide of pre-rendered SVG layers, or re-layout from inlined JSON).
+- Optional: inline a read-only branch **diff/comparison** view (added/removed/changed),
+  reusing the comparison logic described in CLAUDE.md.
+
+### v3 — Polish
+- Dependency arrows, theming (light/dark), print/PDF-friendly layout, legend, title
+  block / metadata (generated date, source branch, filters applied).
+
+---
+
+## Sequencing notes
+
+- **Do not abandon the in-flight canvas/import work.** The exporter consumes the same
+  view model, so that calc layer serves both renderers.
+- **Reprioritize `export.service.ts` to land right after a *minimal usable authoring
+  loop*** (import → see a timeline → switch branch) — not after the canvas is fully
+  polished. The artifact is the deliverable, so it should arrive early, but it needs
+  *something worth exporting* first.
+
+---
+
+## Proposed GitHub issues
+
+> To be created on the board (component:export, component:timeline).
+
+- **[v1] `export.service.ts`: single-branch self-contained HTML exporter**
+  Reuse `timeline.service.ts` view model; emit inlined JSON + embedded SVG renderer;
+  read-only; payload structured for N branches. Acceptance: open exported file offline,
+  see the timeline matching in-app rendering for a chosen branch + filters.
+- **[v1] Export UI entry point**
+  "Export timeline → HTML" action with branch + filter selection and browser download.
+- **[v2] Multi-scenario toggle in exported artifact**
+  Bake N branches; embedded switcher; optional read-only branch diff view.
+- **[v3] Artifact polish**
+  Dependency arrows, theming, print/PDF layout, legend, metadata/title block.
+
+---
+
+## Open questions for later
+
+- Should `build:single` (full-app-in-one-file) and the data-baked artifact coexist as
+  two distinct outputs, or does the artifact eventually supersede `build:single`?
+- Do we want a headless/CLI path (CSV in → artifact HTML out) for automation, or keep
+  generation strictly inside the app?

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -176,7 +176,7 @@ describe('App', () => {
     expect(reloadSpy).toHaveBeenCalled();
   });
 
-  it('renders export tab placeholder', () => {
+  it('renders the export panel on the export tab', () => {
     // Set to export tab
     useAppStore.setState({
       activeTab: 'export',
@@ -187,6 +187,6 @@ describe('App', () => {
 
     render(<App />);
 
-    expect(screen.getByText(/export data/i)).toBeInTheDocument();
+    expect(screen.getByText('Export Timeline → HTML')).toBeInTheDocument();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { TabNavigation } from '@/components/layout/TabNavigation';
 import { PlaceholderPanel } from '@/components/layout/PlaceholderPanel';
 import { TimelineCanvas } from '@/components/timeline/TimelineCanvas';
 import { ImportForm } from '@/components/import/ImportForm';
+import { ExportPanel } from '@/components/export/ExportPanel';
 import { useAppStore } from '@/stores/app.store';
 import { databaseService } from '@/services/database.service';
 import { useTimelineData } from '@/hooks/useTimelineData';
@@ -114,10 +115,9 @@ function App() {
           />
         )}
         {activeTab === 'export' && (
-          <PlaceholderPanel
-            title="Export Data"
-            description="Export your timeline data to various formats."
-          />
+          <div className="min-h-full">
+            <ExportPanel />
+          </div>
         )}
       </main>
     </div>

--- a/src/components/export/ExportPanel.test.tsx
+++ b/src/components/export/ExportPanel.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ExportPanel } from './ExportPanel';
+import { useBranchStore } from '@/stores/branch.store';
+import { useTimelineStore } from '@/stores/timeline.store';
+import { getItems } from '@/db/queries/items.queries';
+import { downloadTextFile } from '@/utils/download.utils';
+import { toast } from 'sonner';
+import type { Item } from '@/types/database.types';
+
+// Radix Select needs these in jsdom
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+}
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+const mockItems: Item[] = [
+  {
+    id: 'a',
+    branch_id: 'main',
+    type: 'task',
+    title: 'Design',
+    start_date: '2025-01-01',
+    end_date: '2025-01-31',
+    owner: 'Alice',
+    lane: 'UX',
+    project: 'Auth',
+    tags: null,
+    dependencies: null,
+    source_id: null,
+    source_row_hash: null,
+    updated_at: '2025-01-01T00:00:00Z',
+  },
+];
+
+vi.mock('@/services/database.service', () => ({
+  databaseService: {
+    isReady: () => true,
+    getDatabase: () => ({}),
+  },
+}));
+
+vi.mock('@/db/queries/items.queries', () => ({
+  getItems: vi.fn(() => mockItems),
+}));
+
+vi.mock('@/utils/download.utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/download.utils')>();
+  return { ...actual, downloadTextFile: vi.fn() };
+});
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+describe('ExportPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useBranchStore.setState({
+      viewBranch: 'main',
+      branches: [
+        { branch_id: 'main', label: 'Main', created_from: null, note: null, created_at: '' },
+      ],
+      refreshBranches: vi.fn().mockResolvedValue(undefined),
+    });
+    useTimelineStore.setState({
+      zoomLevel: 'month',
+      laneGroupBy: 'lane',
+      filterType: '',
+      filterProject: '',
+      filterStartDate: '',
+      filterEndDate: '',
+    });
+  });
+
+  it('renders the export heading and action', () => {
+    render(<ExportPanel />);
+    expect(screen.getByText('Export Timeline → HTML')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /export timeline/i })).toBeInTheDocument();
+  });
+
+  it('exports the selected branch and triggers a download with a generated HTML artifact', async () => {
+    const user = userEvent.setup();
+    render(<ExportPanel />);
+
+    await user.click(screen.getByRole('button', { name: /export timeline/i }));
+
+    await waitFor(() => {
+      expect(getItems).toHaveBeenCalledWith(expect.anything(), 'main');
+      expect(downloadTextFile).toHaveBeenCalledOnce();
+    });
+
+    const [filename, html] = (downloadTextFile as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0] as [string, string];
+    expect(filename).toMatch(/^swimlanes-main-\d{4}-\d{2}-\d{2}\.html$/);
+    expect(html).toContain('<!doctype html>');
+    expect(html).toContain('<svg');
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it('shows an error toast and does not download when item fetch fails', async () => {
+    (getItems as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      throw new Error('boom');
+    });
+    const user = userEvent.setup();
+    render(<ExportPanel />);
+
+    await user.click(screen.getByRole('button', { name: /export timeline/i }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('boom');
+    });
+    expect(downloadTextFile).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/export/ExportPanel.tsx
+++ b/src/components/export/ExportPanel.tsx
@@ -49,13 +49,14 @@ export function ExportPanel() {
     useTimelineStore();
 
   const [branchId, setBranchId] = useState(viewBranch);
+  const [selectedBranchIds, setSelectedBranchIds] = useState<string[]>([viewBranch]);
   const [zoom, setZoom] = useState<ZoomLevel>(zoomLevel);
   const [groupBy, setGroupBy] = useState<LaneGroupBy>(laneGroupBy);
   const [applyFilters, setApplyFilters] = useState(true);
   const [title, setTitle] = useState('');
   const [isExporting, setIsExporting] = useState(false);
 
-  // Ensure branch list is loaded for the selector
+  // Ensure branch list is loaded for the selectors
   useEffect(() => {
     refreshBranches().catch(() => {
       /* surfaced on export attempt */
@@ -63,6 +64,22 @@ export function ExportPanel() {
   }, [refreshBranches]);
 
   const hasActiveFilters = Boolean(filterType || filterProject || filterStartDate || filterEndDate);
+
+  /** The initial scenario is always included. */
+  const includedBranchIds = selectedBranchIds.includes(branchId)
+    ? selectedBranchIds
+    : [branchId, ...selectedBranchIds];
+
+  const toggleBranch = (id: string, checked: boolean) => {
+    setSelectedBranchIds((prev) => {
+      const next = new Set(prev);
+      if (checked) next.add(id);
+      else next.delete(id);
+      // Never drop the initial scenario.
+      next.add(branchId);
+      return Array.from(next);
+    });
+  };
 
   const handleExport = () => {
     setIsExporting(true);
@@ -72,10 +89,6 @@ export function ExportPanel() {
       }
 
       const db = databaseService.getDatabase();
-      const items = getItems(db, branchId);
-
-      const branch = branches.find((b) => b.branch_id === branchId);
-      const label = branch?.label || branchId;
 
       const filters: ExportFilters = applyFilters
         ? {
@@ -86,8 +99,23 @@ export function ExportPanel() {
           }
         : {};
 
+      // Bake the initial scenario first, then any other selected scenarios.
+      const orderedIds = [branchId, ...includedBranchIds.filter((id) => id !== branchId)];
+      const branchInputs = orderedIds.map((id) => {
+        const branch = branches.find((b) => b.branch_id === id);
+        return {
+          branchId: id,
+          label: branch?.label || id,
+          items: getItems(db, id),
+        };
+      });
+
+      const activeBranch = branches.find((b) => b.branch_id === branchId);
+      const activeLabel = activeBranch?.label || branchId;
+      const activeCount = branchInputs.find((b) => b.branchId === branchId)?.items.length ?? 0;
+
       const generatedAt = new Date();
-      const html = generateTimelineArtifact([{ branchId, label, items }], {
+      const html = generateTimelineArtifact(branchInputs, {
         activeBranchId: branchId,
         zoomLevel: zoom,
         laneGroupBy: groupBy,
@@ -96,8 +124,10 @@ export function ExportPanel() {
         generatedAt,
       });
 
-      downloadTextFile(buildArtifactFilename(label, generatedAt), html);
-      toast.success(`Exported timeline for "${label}" (${items.length} items)`);
+      downloadTextFile(buildArtifactFilename(activeLabel, generatedAt), html);
+      const scenarioNote =
+        branchInputs.length > 1 ? ` + ${branchInputs.length - 1} scenario(s)` : '';
+      toast.success(`Exported "${activeLabel}" (${activeCount} items)${scenarioNote}`);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to export timeline';
       console.error('Export failed:', error);
@@ -114,14 +144,15 @@ export function ExportPanel() {
           <h2 className="text-xl font-semibold">Export Timeline → HTML</h2>
           <p className="mt-1 text-sm text-muted-foreground">
             Generate a single, self-contained HTML file with the timeline and data baked in. It
-            opens in any browser offline — no app or server required.
+            opens in any browser offline — no app or server required. Include multiple branches to
+            bake in scenarios the reader can toggle between.
           </p>
         </div>
 
         <div className="space-y-4">
-          {/* Branch */}
+          {/* Initial scenario */}
           <div className="space-y-1.5">
-            <Label htmlFor="export-branch">Branch</Label>
+            <Label htmlFor="export-branch">Initial scenario (branch)</Label>
             <Select value={branchId} onValueChange={setBranchId}>
               <SelectTrigger id="export-branch" className="w-full">
                 <SelectValue />
@@ -135,6 +166,41 @@ export function ExportPanel() {
               </SelectContent>
             </Select>
           </div>
+
+          {/* Additional scenarios to bake in */}
+          {branches.length > 1 && (
+            <div className="space-y-1.5">
+              <Label>Include scenarios</Label>
+              <div className="rounded-md border border-border p-3 space-y-2">
+                {branches.map((branch) => {
+                  const isActive = branch.branch_id === branchId;
+                  const checked = isActive || includedBranchIds.includes(branch.branch_id);
+                  return (
+                    <div key={branch.branch_id} className="flex items-center gap-2">
+                      <input
+                        id={`scenario-${branch.branch_id}`}
+                        type="checkbox"
+                        className="h-4 w-4 rounded border-border accent-primary"
+                        checked={checked}
+                        disabled={isActive}
+                        onChange={(e) => toggleBranch(branch.branch_id, e.target.checked)}
+                      />
+                      <Label
+                        htmlFor={`scenario-${branch.branch_id}`}
+                        className="cursor-pointer font-normal"
+                      >
+                        {branch.label || branch.branch_id}
+                        {isActive && <span className="ml-1 text-muted-foreground">(initial)</span>}
+                      </Label>
+                    </div>
+                  );
+                })}
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Readers can switch between included scenarios in the exported file.
+              </p>
+            </div>
+          )}
 
           {/* Zoom + Group by */}
           <div className="grid grid-cols-2 gap-4">

--- a/src/components/export/ExportPanel.tsx
+++ b/src/components/export/ExportPanel.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useState } from 'react';
+import { Download } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card } from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useBranchStore } from '@/stores/branch.store';
+import { useTimelineStore } from '@/stores/timeline.store';
+import { databaseService } from '@/services/database.service';
+import { getItems } from '@/db/queries/items.queries';
+import { generateTimelineArtifact } from '@/services/export.service';
+import { buildArtifactFilename, downloadTextFile } from '@/utils/download.utils';
+import type { ZoomLevel, LaneGroupBy } from '@/types/timeline.types';
+import type { ExportFilters } from '@/types/export.types';
+
+const ZOOM_OPTIONS: { value: ZoomLevel; label: string }[] = [
+  { value: 'day', label: 'Day' },
+  { value: 'week', label: 'Week' },
+  { value: 'month', label: 'Month' },
+  { value: 'quarter', label: 'Quarter' },
+  { value: 'year', label: 'Year' },
+];
+
+const GROUP_BY_OPTIONS: { value: LaneGroupBy; label: string }[] = [
+  { value: 'lane', label: 'Lane' },
+  { value: 'project', label: 'Project' },
+  { value: 'owner', label: 'Owner' },
+  { value: 'type', label: 'Type' },
+];
+
+/**
+ * ExportPanel - Generates a standalone, self-contained HTML timeline artifact
+ * for a selected branch and triggers a browser download.
+ *
+ * Defaults mirror the current timeline view (branch, zoom, grouping) and the
+ * active timeline filters can optionally be baked in. See `export.service.ts`.
+ */
+export function ExportPanel() {
+  const { viewBranch, branches, refreshBranches } = useBranchStore();
+  const { zoomLevel, laneGroupBy, filterType, filterProject, filterStartDate, filterEndDate } =
+    useTimelineStore();
+
+  const [branchId, setBranchId] = useState(viewBranch);
+  const [zoom, setZoom] = useState<ZoomLevel>(zoomLevel);
+  const [groupBy, setGroupBy] = useState<LaneGroupBy>(laneGroupBy);
+  const [applyFilters, setApplyFilters] = useState(true);
+  const [title, setTitle] = useState('');
+  const [isExporting, setIsExporting] = useState(false);
+
+  // Ensure branch list is loaded for the selector
+  useEffect(() => {
+    refreshBranches().catch(() => {
+      /* surfaced on export attempt */
+    });
+  }, [refreshBranches]);
+
+  const hasActiveFilters = Boolean(filterType || filterProject || filterStartDate || filterEndDate);
+
+  const handleExport = () => {
+    setIsExporting(true);
+    try {
+      if (!databaseService.isReady()) {
+        throw new Error('Database is not ready yet');
+      }
+
+      const db = databaseService.getDatabase();
+      const items = getItems(db, branchId);
+
+      const branch = branches.find((b) => b.branch_id === branchId);
+      const label = branch?.label || branchId;
+
+      const filters: ExportFilters = applyFilters
+        ? {
+            type: filterType || undefined,
+            project: filterProject || undefined,
+            startDate: filterStartDate || undefined,
+            endDate: filterEndDate || undefined,
+          }
+        : {};
+
+      const generatedAt = new Date();
+      const html = generateTimelineArtifact([{ branchId, label, items }], {
+        activeBranchId: branchId,
+        zoomLevel: zoom,
+        laneGroupBy: groupBy,
+        filters,
+        title: title.trim() || undefined,
+        generatedAt,
+      });
+
+      downloadTextFile(buildArtifactFilename(label, generatedAt), html);
+      toast.success(`Exported timeline for "${label}" (${items.length} items)`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to export timeline';
+      console.error('Export failed:', error);
+      toast.error(message);
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-2xl p-6">
+      <Card className="p-6">
+        <div className="mb-6">
+          <h2 className="text-xl font-semibold">Export Timeline → HTML</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Generate a single, self-contained HTML file with the timeline and data baked in. It
+            opens in any browser offline — no app or server required.
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          {/* Branch */}
+          <div className="space-y-1.5">
+            <Label htmlFor="export-branch">Branch</Label>
+            <Select value={branchId} onValueChange={setBranchId}>
+              <SelectTrigger id="export-branch" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {branches.map((branch) => (
+                  <SelectItem key={branch.branch_id} value={branch.branch_id}>
+                    {branch.label || branch.branch_id}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Zoom + Group by */}
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="export-zoom">Zoom</Label>
+              <Select value={zoom} onValueChange={(v) => setZoom(v as ZoomLevel)}>
+                <SelectTrigger id="export-zoom" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {ZOOM_OPTIONS.map((o) => (
+                    <SelectItem key={o.value} value={o.value}>
+                      {o.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="export-group">Group by</Label>
+              <Select value={groupBy} onValueChange={(v) => setGroupBy(v as LaneGroupBy)}>
+                <SelectTrigger id="export-group" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {GROUP_BY_OPTIONS.map((o) => (
+                    <SelectItem key={o.value} value={o.value}>
+                      {o.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {/* Title */}
+          <div className="space-y-1.5">
+            <Label htmlFor="export-title">Title (optional)</Label>
+            <Input
+              id="export-title"
+              type="text"
+              placeholder="SwimLanes Timeline — …"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+          </div>
+
+          {/* Apply filters */}
+          <div className="flex items-center gap-2">
+            <input
+              id="export-apply-filters"
+              type="checkbox"
+              className="h-4 w-4 rounded border-border accent-primary"
+              checked={applyFilters}
+              onChange={(e) => setApplyFilters(e.target.checked)}
+            />
+            <Label htmlFor="export-apply-filters" className="cursor-pointer font-normal">
+              Apply current timeline filters
+              {hasActiveFilters ? (
+                <span className="ml-1 text-muted-foreground">(filters are active)</span>
+              ) : (
+                <span className="ml-1 text-muted-foreground">(none active)</span>
+              )}
+            </Label>
+          </div>
+
+          <Button onClick={handleExport} disabled={isExporting} className="gap-2">
+            <Download className="h-4 w-4" />
+            {isExporting ? 'Exporting…' : 'Export timeline → HTML'}
+          </Button>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/layout/TabNavigation.tsx
+++ b/src/components/layout/TabNavigation.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useState } from 'react';
-import { FileUp, LineChart, GitBranch, History, ChevronDown, ChevronUp } from 'lucide-react';
+import {
+  FileUp,
+  LineChart,
+  GitBranch,
+  History,
+  Download,
+  ChevronDown,
+  ChevronUp,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -27,6 +35,7 @@ const tabs: TabConfig[] = [
   { id: 'timeline', label: 'Timeline', icon: LineChart },
   { id: 'branches', label: 'Branches', icon: GitBranch },
   { id: 'history', label: 'History', icon: History },
+  { id: 'export', label: 'Export', icon: Download },
 ];
 
 /**

--- a/src/services/export.service.test.ts
+++ b/src/services/export.service.test.ts
@@ -7,6 +7,8 @@ import {
   filterItems,
   buildRenderModel,
   renderSvg,
+  renderChartSvg,
+  renderGutterSvg,
   escapeXml,
   parseDependencies,
   generateTimelineArtifact,
@@ -193,10 +195,46 @@ describe('export.service', () => {
     });
   });
 
+  describe('renderChartSvg / renderGutterSvg (frozen lane labels)', () => {
+    it('chart svg omits lane labels and crops the left margin via viewBox', () => {
+      const model = buildRenderModel(SAMPLE_ITEMS, 'month', 'lane');
+      const chart = renderChartSvg(model);
+      expect(chart).not.toContain('class="lane-label"');
+      // viewBox starts at the left margin (default 150), so the gutter area is cropped.
+      expect(chart).toContain(`viewBox="${model.config.margin.left} 0`);
+      // Chart still has the timeline content.
+      expect(chart).toContain('<rect');
+      expect(chart).toContain('class="axis-label"');
+    });
+
+    it('gutter svg contains the lane labels and is the margin width', () => {
+      const model = buildRenderModel(SAMPLE_ITEMS, 'month', 'lane');
+      const gutter = renderGutterSvg(model);
+      expect(gutter).toContain('class="lane-label"');
+      expect(gutter).toContain(`width="${model.config.margin.left}"`);
+      // Lane names appear in the gutter, not the chart.
+      expect(gutter).toContain('Backend');
+    });
+
+    it('draws a Today marker only when the date is within range', () => {
+      const model = buildRenderModel(SAMPLE_ITEMS, 'month', 'lane'); // range 2025-01-01..03-01
+      expect(renderChartSvg(model, { nowDate: '2025-02-01' })).toContain('class="today-line"');
+      expect(renderChartSvg(model, { nowDate: '2030-01-01' })).not.toContain('class="today-line"');
+      expect(renderChartSvg(model)).not.toContain('class="today-line"');
+    });
+  });
+
   describe('generateTimelineArtifact', () => {
     const branches: ExportBranchInput[] = [
       { branchId: 'main', label: 'Main', items: SAMPLE_ITEMS },
     ];
+
+    it('wraps each branch in a frozen-gutter frame', () => {
+      const html = generateTimelineArtifact(branches, { activeBranchId: 'main' });
+      expect(html).toContain('class="timeline-frame"');
+      expect(html).toContain('class="lane-gutter"');
+      expect(html).toContain('class="timeline-scroll"');
+    });
 
     it('produces a self-contained HTML document with inlined svg and data', () => {
       const html = generateTimelineArtifact(branches, { activeBranchId: 'main' });

--- a/src/services/export.service.test.ts
+++ b/src/services/export.service.test.ts
@@ -216,6 +216,17 @@ describe('export.service', () => {
       expect(dataBlock).not.toContain('</script><script>bad()');
     });
 
+    it('renders a single branch without a switcher or switcher script', () => {
+      const html = generateTimelineArtifact(branches, { activeBranchId: 'main' });
+      // No switcher markup or buttons (the .scenario-* CSS rules are always present).
+      expect(html).not.toContain('<div class="scenario-switcher"');
+      expect(html).not.toContain('class="scenario-btn');
+      expect(html).not.toContain('addEventListener');
+      // Exactly one branch view, shown (not hidden)
+      const views = html.match(/<section class="branch-view"/g) ?? [];
+      expect(views).toHaveLength(1);
+    });
+
     it('throws when the active branch is missing', () => {
       expect(() =>
         generateTimelineArtifact(branches, { activeBranchId: 'does-not-exist' })
@@ -230,6 +241,62 @@ describe('export.service', () => {
       });
       expect(html).toContain('Main');
       expect(html).toContain('SwimLanes Timeline');
+    });
+  });
+
+  describe('generateTimelineArtifact (multi-scenario)', () => {
+    const multi: ExportBranchInput[] = [
+      { branchId: 'main', label: 'Main', items: SAMPLE_ITEMS },
+      {
+        branchId: 'aggressive',
+        label: 'Aggressive',
+        items: [
+          ...SAMPLE_ITEMS,
+          makeItem({ id: 'd', title: 'Extra feature', project: 'Auth', lane: 'Backend' }),
+        ],
+      },
+    ];
+
+    it('bakes every branch into one file with a switcher button each', () => {
+      const html = generateTimelineArtifact(multi, { activeBranchId: 'main' });
+      const buttons = html.match(/class="scenario-btn/g) ?? [];
+      expect(buttons).toHaveLength(2);
+      expect(html).toContain('data-branch-id="main"');
+      expect(html).toContain('data-branch-id="aggressive"');
+      // Per-branch item counts surfaced on the buttons (3 vs 4)
+      expect(html).toContain('data-item-count="3"');
+      expect(html).toContain('data-item-count="4"');
+    });
+
+    it('renders all branch views with only the active one visible', () => {
+      const html = generateTimelineArtifact(multi, { activeBranchId: 'aggressive' });
+      const views = html.match(/<section class="branch-view"[^>]*>/g) ?? [];
+      expect(views).toHaveLength(2);
+      // The active branch's section is not hidden; the other is.
+      const activeSection = views.find((v) => v.includes('data-branch-id="aggressive"'));
+      const otherSection = views.find((v) => v.includes('data-branch-id="main"'));
+      expect(activeSection).toBeDefined();
+      expect(activeSection).not.toContain('hidden');
+      expect(otherSection).toContain('hidden');
+    });
+
+    it('marks the active scenario button pressed and embeds the toggle script', () => {
+      const html = generateTimelineArtifact(multi, { activeBranchId: 'aggressive' });
+      expect(html).toContain('addEventListener');
+      const activeBtn = html
+        .split('\n')
+        .find((l) => l.includes('data-branch-id="aggressive"') && l.includes('scenario-btn'));
+      expect(activeBtn).toContain('aria-pressed="true"');
+      expect(activeBtn).toContain('active');
+    });
+
+    it('embeds all branches in the JSON payload', () => {
+      const html = generateTimelineArtifact(multi, { activeBranchId: 'main' });
+      const match = html.match(
+        /<script type="application\/json" id="swimlanes-data">\s*([\s\S]*?)\s*<\/script>/
+      );
+      const payload = JSON.parse(match![1]!) as ExportPayload;
+      expect(payload.branches.map((b) => b.branchId)).toEqual(['main', 'aggressive']);
     });
   });
 });

--- a/src/services/export.service.test.ts
+++ b/src/services/export.service.test.ts
@@ -236,6 +236,29 @@ describe('export.service', () => {
       expect(renderBodySvg(model, { nowDate: '2030-01-01' })).not.toContain('class="today-line"');
       expect(renderBodySvg(model)).not.toContain('class="today-line"');
     });
+
+    it('shades alternating period bands at month zoom and weekends at day zoom', () => {
+      // Jan–Mar spans >1 month, so an alternating month band is drawn.
+      expect(renderBodySvg(model, { zoom: 'month' })).toContain('class="period-band"');
+      // A multi-quarter range yields an alternating quarter band.
+      const wide = buildRenderModel(
+        [makeItem({ id: 'w', lane: 'A', start_date: '2025-01-01', end_date: '2025-09-30' })],
+        'quarter',
+        'lane'
+      );
+      expect(renderBodySvg(wide, { zoom: 'quarter' })).toContain('class="period-band"');
+      const dayModel = buildRenderModel(SAMPLE_ITEMS, 'day', 'lane');
+      expect(renderBodySvg(dayModel, { zoom: 'day' })).toContain('class="weekend-band"');
+      // No zoom -> no bands
+      expect(renderBodySvg(model)).not.toContain('period-band');
+    });
+
+    it('shows a per-lane item count badge in the labels pane', () => {
+      const labels = renderLabelsSvg(model);
+      expect(labels).toContain('class="lane-count"');
+      // SAMPLE_ITEMS: Backend lane has 1 item (API work); count text present.
+      expect(labels).toMatch(/class="lane-count"[^>]*>\d+<\/text>/);
+    });
   });
 
   describe('generateTimelineArtifact', () => {

--- a/src/services/export.service.test.ts
+++ b/src/services/export.service.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Tests for the HTML timeline artifact export service.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  filterItems,
+  buildRenderModel,
+  renderSvg,
+  escapeXml,
+  generateTimelineArtifact,
+  EXPORT_FORMAT_VERSION,
+} from './export.service';
+import type { Item } from '../types/database.types';
+import type { ExportBranchInput, ExportPayload } from '../types/export.types';
+
+/**
+ * Builds a minimal valid Item with sensible defaults. Uses a spread so that
+ * explicit `null` overrides (e.g. a milestone's end_date) are respected.
+ */
+function makeItem(overrides: Partial<Item> = {}): Item {
+  return {
+    id: 'i1',
+    branch_id: 'main',
+    type: 'task',
+    title: 'Task One',
+    start_date: '2025-01-01',
+    end_date: '2025-01-31',
+    owner: 'Alice',
+    lane: 'Backend',
+    project: 'Auth',
+    tags: null,
+    dependencies: null,
+    source_id: null,
+    source_row_hash: null,
+    updated_at: '2025-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+const SAMPLE_ITEMS: Item[] = [
+  makeItem({ id: 'a', title: 'Design', type: 'task', project: 'Auth', lane: 'UX' }),
+  makeItem({
+    id: 'b',
+    title: 'Launch',
+    type: 'milestone',
+    start_date: '2025-02-15',
+    end_date: null,
+    project: 'Auth',
+    lane: 'Release',
+  }),
+  makeItem({
+    id: 'c',
+    title: 'API work',
+    type: 'task',
+    start_date: '2025-01-10',
+    end_date: '2025-03-01',
+    project: 'Payments',
+    lane: 'Backend',
+  }),
+];
+
+describe('export.service', () => {
+  describe('filterItems', () => {
+    it('returns all items when no filters are given', () => {
+      expect(filterItems(SAMPLE_ITEMS)).toHaveLength(3);
+    });
+
+    it('filters by exact type', () => {
+      const result = filterItems(SAMPLE_ITEMS, { type: 'milestone' });
+      expect(result).toHaveLength(1);
+      expect(result[0]?.id).toBe('b');
+    });
+
+    it('filters by project with partial, case-insensitive match', () => {
+      const result = filterItems(SAMPLE_ITEMS, { project: 'pay' });
+      expect(result.map((i) => i.id)).toEqual(['c']);
+    });
+
+    it('filters by start date (item must end on or after)', () => {
+      const result = filterItems(SAMPLE_ITEMS, { startDate: '2025-02-01' });
+      // 'a' ends 2025-01-31 -> excluded; 'b' milestone (no end) kept; 'c' ends 03-01 kept
+      expect(result.map((i) => i.id).sort()).toEqual(['b', 'c']);
+    });
+
+    it('filters by end date (item must start on or before)', () => {
+      const result = filterItems(SAMPLE_ITEMS, { endDate: '2025-01-05' });
+      // only 'a' starts 2025-01-01 <= 2025-01-05
+      expect(result.map((i) => i.id)).toEqual(['a']);
+    });
+  });
+
+  describe('escapeXml', () => {
+    it('escapes the five XML metacharacters', () => {
+      expect(escapeXml(`<a href="x" id='y'>& </a>`)).toBe(
+        '&lt;a href=&quot;x&quot; id=&#39;y&#39;&gt;&amp; &lt;/a&gt;'
+      );
+    });
+  });
+
+  describe('buildRenderModel', () => {
+    it('computes lane groups, date range, and positive SVG dimensions', () => {
+      const model = buildRenderModel(SAMPLE_ITEMS, 'month', 'lane');
+      expect(model.dateRange.minDate).toBe('2025-01-01');
+      expect(model.dateRange.maxDate).toBe('2025-03-01');
+      expect(model.laneGroups.length).toBeGreaterThan(0);
+      expect(model.svgWidth).toBeGreaterThan(0);
+      expect(model.svgHeight).toBeGreaterThan(model.config.margin.top);
+    });
+
+    it('groups by the requested strategy', () => {
+      const byType = buildRenderModel(SAMPLE_ITEMS, 'month', 'type');
+      const names = byType.laneGroups.map((l) => l.laneName).sort();
+      expect(names).toEqual(['milestone', 'task']);
+    });
+
+    it('handles an empty item list without throwing', () => {
+      const model = buildRenderModel([], 'month', 'lane');
+      expect(model.laneGroups).toHaveLength(0);
+      expect(model.dateRange.minDate).toBeNull();
+    });
+  });
+
+  describe('renderSvg', () => {
+    it('produces an svg root element with matching dimensions', () => {
+      const model = buildRenderModel(SAMPLE_ITEMS, 'month', 'lane');
+      const svg = renderSvg(model);
+      expect(svg.startsWith('<svg')).toBe(true);
+      expect(svg.trimEnd().endsWith('</svg>')).toBe(true);
+      expect(svg).toContain(`width="${model.svgWidth}"`);
+    });
+
+    it('renders milestones as polygons (diamonds) and tasks as rects', () => {
+      const model = buildRenderModel(SAMPLE_ITEMS, 'month', 'lane');
+      const svg = renderSvg(model);
+      expect(svg).toContain('<polygon');
+      expect(svg).toContain('<rect');
+    });
+
+    it('renders an empty-state message when there are no dated items', () => {
+      const model = buildRenderModel([], 'month', 'lane');
+      const svg = renderSvg(model);
+      expect(svg).toContain('No dated items to display');
+    });
+
+    it('escapes item titles to prevent markup injection', () => {
+      const evil = [makeItem({ id: 'x', title: '<script>alert(1)</script>', type: 'milestone' })];
+      const model = buildRenderModel(evil, 'month', 'lane');
+      const svg = renderSvg(model);
+      expect(svg).not.toContain('<script>alert(1)</script>');
+      expect(svg).toContain('&lt;script&gt;');
+    });
+  });
+
+  describe('generateTimelineArtifact', () => {
+    const branches: ExportBranchInput[] = [
+      { branchId: 'main', label: 'Main', items: SAMPLE_ITEMS },
+    ];
+
+    it('produces a self-contained HTML document with inlined svg and data', () => {
+      const html = generateTimelineArtifact(branches, { activeBranchId: 'main' });
+      expect(html.startsWith('<!doctype html>')).toBe(true);
+      expect(html).toContain('<svg');
+      expect(html).toContain('id="swimlanes-data"');
+      // No external/network resource references. (The SVG xmlns namespace URI is
+      // an identifier, not something the browser fetches, so it's allowed.)
+      expect(html).not.toMatch(/src=["']https?:/);
+      expect(html).not.toMatch(/href=["']https?:/);
+      expect(html).not.toMatch(/url\(https?:/);
+      expect(html).not.toContain('<script src');
+      expect(html).not.toContain('cdnjs');
+    });
+
+    it('embeds a parseable payload structured for N branches', () => {
+      const html = generateTimelineArtifact(branches, {
+        activeBranchId: 'main',
+        zoomLevel: 'month',
+        laneGroupBy: 'project',
+      });
+      const match = html.match(
+        /<script type="application\/json" id="swimlanes-data">\s*([\s\S]*?)\s*<\/script>/
+      );
+      expect(match).not.toBeNull();
+      const payload = JSON.parse(match![1]!) as ExportPayload;
+      expect(payload.formatVersion).toBe(EXPORT_FORMAT_VERSION);
+      expect(payload.activeBranchId).toBe('main');
+      expect(payload.branches).toHaveLength(1);
+      expect(payload.branches[0]?.items).toHaveLength(3);
+      expect(payload.laneGroupBy).toBe('project');
+    });
+
+    it('applies filters to the rendered branch and the embedded payload', () => {
+      const html = generateTimelineArtifact(branches, {
+        activeBranchId: 'main',
+        filters: { type: 'milestone' },
+      });
+      const match = html.match(
+        /<script type="application\/json" id="swimlanes-data">\s*([\s\S]*?)\s*<\/script>/
+      );
+      const payload = JSON.parse(match![1]!) as ExportPayload;
+      expect(payload.branches[0]?.items).toHaveLength(1);
+      expect(payload.branches[0]?.items[0]?.type).toBe('milestone');
+    });
+
+    it('neutralizes a </script> sequence inside embedded data', () => {
+      const tricky: ExportBranchInput[] = [
+        {
+          branchId: 'main',
+          label: 'Main',
+          items: [makeItem({ id: 'evil', title: 'pwn </script><script>bad()</script>' })],
+        },
+      ];
+      const html = generateTimelineArtifact(tricky, { activeBranchId: 'main' });
+      // The data script block must not be broken open by the payload contents.
+      const dataBlock = html.split('id="swimlanes-data">')[1] ?? '';
+      expect(dataBlock).not.toContain('</script><script>bad()');
+    });
+
+    it('throws when the active branch is missing', () => {
+      expect(() =>
+        generateTimelineArtifact(branches, { activeBranchId: 'does-not-exist' })
+      ).toThrow(/not found/);
+    });
+
+    it('uses the branch label and generation time in the header', () => {
+      const when = new Date('2026-06-25T12:00:00Z');
+      const html = generateTimelineArtifact(branches, {
+        activeBranchId: 'main',
+        generatedAt: when,
+      });
+      expect(html).toContain('Main');
+      expect(html).toContain('SwimLanes Timeline');
+    });
+  });
+});

--- a/src/services/export.service.test.ts
+++ b/src/services/export.service.test.ts
@@ -7,8 +7,10 @@ import {
   filterItems,
   buildRenderModel,
   renderSvg,
-  renderChartSvg,
-  renderGutterSvg,
+  renderCornerSvg,
+  renderAxisSvg,
+  renderLabelsSvg,
+  renderBodySvg,
   escapeXml,
   parseDependencies,
   generateTimelineArtifact,
@@ -195,32 +197,44 @@ describe('export.service', () => {
     });
   });
 
-  describe('renderChartSvg / renderGutterSvg (frozen lane labels)', () => {
-    it('chart svg omits lane labels and crops the left margin via viewBox', () => {
-      const model = buildRenderModel(SAMPLE_ITEMS, 'month', 'lane');
-      const chart = renderChartSvg(model);
-      expect(chart).not.toContain('class="lane-label"');
-      // viewBox starts at the left margin (default 150), so the gutter area is cropped.
-      expect(chart).toContain(`viewBox="${model.config.margin.left} 0`);
-      // Chart still has the timeline content.
-      expect(chart).toContain('<rect');
-      expect(chart).toContain('class="axis-label"');
+  describe('frozen-pane renderers (corner / axis / labels / body)', () => {
+    const model = buildRenderModel(SAMPLE_ITEMS, 'month', 'lane'); // range 2025-01-01..03-01
+
+    it('corner pane is the margin size and labels the lane column', () => {
+      const corner = renderCornerSvg(model);
+      expect(corner).toContain(`width="${model.config.margin.left}"`);
+      expect(corner).toContain(`height="${model.config.margin.top}"`);
+      expect(corner).toContain('Lanes');
     });
 
-    it('gutter svg contains the lane labels and is the margin width', () => {
-      const model = buildRenderModel(SAMPLE_ITEMS, 'month', 'lane');
-      const gutter = renderGutterSvg(model);
-      expect(gutter).toContain('class="lane-label"');
-      expect(gutter).toContain(`width="${model.config.margin.left}"`);
-      // Lane names appear in the gutter, not the chart.
-      expect(gutter).toContain('Backend');
+    it('axis pane has ticks but no lane labels, cropped to the top strip', () => {
+      const axis = renderAxisSvg(model);
+      expect(axis).toContain('class="axis-label"');
+      expect(axis).not.toContain('class="lane-label"');
+      expect(axis).toContain(`viewBox="${model.config.margin.left} 0`);
+      expect(axis).toContain(`height="${model.config.margin.top}"`);
     });
 
-    it('draws a Today marker only when the date is within range', () => {
-      const model = buildRenderModel(SAMPLE_ITEMS, 'month', 'lane'); // range 2025-01-01..03-01
-      expect(renderChartSvg(model, { nowDate: '2025-02-01' })).toContain('class="today-line"');
-      expect(renderChartSvg(model, { nowDate: '2030-01-01' })).not.toContain('class="today-line"');
-      expect(renderChartSvg(model)).not.toContain('class="today-line"');
+    it('labels pane has lane labels, cropped below the axis', () => {
+      const labels = renderLabelsSvg(model);
+      expect(labels).toContain('class="lane-label"');
+      expect(labels).toContain('Backend');
+      expect(labels).toContain(`viewBox="0 ${model.config.margin.top}`);
+      expect(labels).not.toContain('class="axis-label"');
+    });
+
+    it('body pane has items and crops out the label margin and axis', () => {
+      const body = renderBodySvg(model);
+      expect(body).toContain('<rect');
+      expect(body).not.toContain('class="lane-label"');
+      expect(body).not.toContain('class="axis-label"');
+      expect(body).toContain(`viewBox="${model.config.margin.left} ${model.config.margin.top}`);
+    });
+
+    it('draws a Today marker in the body only when the date is within range', () => {
+      expect(renderBodySvg(model, { nowDate: '2025-02-01' })).toContain('class="today-line"');
+      expect(renderBodySvg(model, { nowDate: '2030-01-01' })).not.toContain('class="today-line"');
+      expect(renderBodySvg(model)).not.toContain('class="today-line"');
     });
   });
 
@@ -229,11 +243,42 @@ describe('export.service', () => {
       { branchId: 'main', label: 'Main', items: SAMPLE_ITEMS },
     ];
 
-    it('wraps each branch in a frozen-gutter frame', () => {
+    it('wraps each branch in a frozen-pane grid (corner/axis/labels/body)', () => {
       const html = generateTimelineArtifact(branches, { activeBranchId: 'main' });
-      expect(html).toContain('class="timeline-frame"');
-      expect(html).toContain('class="lane-gutter"');
-      expect(html).toContain('class="timeline-scroll"');
+      expect(html).toContain('class="timeline-viewport"');
+      expect(html).toContain('class="timeline-grid"');
+      expect(html).toContain('class="corner"');
+      expect(html).toContain('class="axis-col"');
+      expect(html).toContain('class="labels-col"');
+      expect(html).toContain('class="body-col"');
+    });
+
+    it('bakes multiple zoom levels with a zoom switcher and dynamic meta', () => {
+      const html = generateTimelineArtifact(branches, {
+        activeBranchId: 'main',
+        zoomLevel: 'month',
+        zoomLevels: ['week', 'month', 'quarter'],
+      });
+      expect(html).toContain('class="zoom-switcher"');
+      expect(html).toContain('data-zoom="week"');
+      expect(html).toContain('data-zoom="quarter"');
+      expect(html).toContain('id="meta-zoom"');
+      expect(html).toContain("querySelectorAll('.zoom-pane')");
+      // The active zoom button is pressed.
+      const monthBtn = html
+        .split('\n')
+        .find((l) => l.includes('data-zoom="month"') && l.includes('zoom-btn'));
+      expect(monthBtn).toContain('aria-pressed="true"');
+    });
+
+    it('omits the zoom switcher when only one zoom level is baked', () => {
+      const html = generateTimelineArtifact(branches, {
+        activeBranchId: 'main',
+        zoomLevel: 'month',
+        zoomLevels: ['month'],
+      });
+      expect(html).not.toContain('class="zoom-switcher"');
+      expect(html).not.toContain("querySelectorAll('.zoom-pane')");
     });
 
     it('produces a self-contained HTML document with inlined svg and data', () => {

--- a/src/services/export.service.test.ts
+++ b/src/services/export.service.test.ts
@@ -8,6 +8,7 @@ import {
   buildRenderModel,
   renderSvg,
   escapeXml,
+  parseDependencies,
   generateTimelineArtifact,
   EXPORT_FORMAT_VERSION,
 } from './export.service';
@@ -98,6 +99,23 @@ describe('export.service', () => {
     });
   });
 
+  describe('parseDependencies', () => {
+    it('parses a JSON array of ids', () => {
+      expect(parseDependencies('["a","b"]')).toEqual(['a', 'b']);
+    });
+
+    it('returns [] for null, empty, or invalid JSON', () => {
+      expect(parseDependencies(null)).toEqual([]);
+      expect(parseDependencies('')).toEqual([]);
+      expect(parseDependencies('not json')).toEqual([]);
+      expect(parseDependencies('{"a":1}')).toEqual([]);
+    });
+
+    it('drops non-string entries', () => {
+      expect(parseDependencies('["a",1,null,"b"]')).toEqual(['a', 'b']);
+    });
+  });
+
   describe('buildRenderModel', () => {
     it('computes lane groups, date range, and positive SVG dimensions', () => {
       const model = buildRenderModel(SAMPLE_ITEMS, 'month', 'lane');
@@ -141,6 +159,29 @@ describe('export.service', () => {
       const model = buildRenderModel([], 'month', 'lane');
       const svg = renderSvg(model);
       expect(svg).toContain('No dated items to display');
+    });
+
+    it('draws a dependency arrow when an item depends on another visible item', () => {
+      const items = [
+        makeItem({ id: 'a', title: 'First', start_date: '2025-01-01', end_date: '2025-01-15' }),
+        makeItem({
+          id: 'b',
+          title: 'Second',
+          start_date: '2025-01-20',
+          end_date: '2025-02-01',
+          dependencies: '["a"]',
+        }),
+      ];
+      const svg = renderSvg(buildRenderModel(items, 'month', 'lane'));
+      expect(svg).toContain('class="dep-arrow"');
+      expect(svg).toContain('marker-end="url(#dep-arrowhead)"');
+      expect(svg).toContain('id="dep-arrowhead"');
+    });
+
+    it('does not draw an arrow when the dependency is not present', () => {
+      const items = [makeItem({ id: 'b', title: 'Second', dependencies: '["missing"]' })];
+      const svg = renderSvg(buildRenderModel(items, 'month', 'lane'));
+      expect(svg).not.toContain('class="dep-arrow"');
     });
 
     it('escapes item titles to prevent markup injection', () => {
@@ -218,10 +259,11 @@ describe('export.service', () => {
 
     it('renders a single branch without a switcher or switcher script', () => {
       const html = generateTimelineArtifact(branches, { activeBranchId: 'main' });
-      // No switcher markup or buttons (the .scenario-* CSS rules are always present).
+      // No switcher markup, buttons, or switcher script (the .scenario-* CSS
+      // rules and the theme script are always present, so target specifics).
       expect(html).not.toContain('<div class="scenario-switcher"');
       expect(html).not.toContain('class="scenario-btn');
-      expect(html).not.toContain('addEventListener');
+      expect(html).not.toContain("querySelectorAll('.scenario-btn')");
       // Exactly one branch view, shown (not hidden)
       const views = html.match(/<section class="branch-view"/g) ?? [];
       expect(views).toHaveLength(1);
@@ -231,6 +273,15 @@ describe('export.service', () => {
       expect(() =>
         generateTimelineArtifact(branches, { activeBranchId: 'does-not-exist' })
       ).toThrow(/not found/);
+    });
+
+    it('includes a theme toggle, theme script, and print styles', () => {
+      const html = generateTimelineArtifact(branches, { activeBranchId: 'main' });
+      expect(html).toContain('id="theme-toggle"');
+      expect(html).toContain("setAttribute('data-theme'");
+      expect(html).toContain('prefers-color-scheme: dark');
+      expect(html).toContain('@media print');
+      expect(html).toContain('data-theme="dark"'); // dark theme CSS block
     });
 
     it('uses the branch label and generation time in the header', () => {

--- a/src/services/export.service.ts
+++ b/src/services/export.service.ts
@@ -1,0 +1,440 @@
+/**
+ * HTML Timeline Artifact Export Service
+ *
+ * Generates a standalone, self-contained HTML file rendering a branch's timeline
+ * as hand-rolled SVG, with the dataset inlined as JSON. The output opens in any
+ * browser, offline, with no app, server, sql.js, or React runtime.
+ *
+ * This is the flagship *output* of SwimLanes (the app remains the authoring
+ * tool). See `ref/html-artifact-export.md` for positioning and rationale.
+ *
+ * Design notes:
+ * - The exporter is a *consumer* of `timeline.service.ts` — it reuses the same
+ *   layout math the in-app canvas uses, so the artifact matches what users see.
+ * - v1 renders a single branch. The embedded payload is structured for N
+ *   branches so v2 (multi-scenario toggle) is purely additive.
+ * - The artifact is read-only: no edit/re-import logic is embedded.
+ *
+ * All functions are pure for easy testing.
+ */
+
+import type { Item } from '../types/database.types';
+import type { ZoomLevel, LaneGroupBy, TimelineConfig } from '../types/timeline.types';
+import type {
+  ExportOptions,
+  ExportBranchInput,
+  ExportFilters,
+  ExportRenderModel,
+  ExportPayload,
+} from '../types/export.types';
+import {
+  groupItemsByLane,
+  calculateDateRange,
+  createLaneGroups,
+  calculateTimeAxisTicks,
+  calculateChartWidth,
+  calculateItemPosition,
+  assignItemRows,
+  DEFAULT_ITEM_COLORS,
+} from './timeline.service';
+
+/** Current artifact format version. Bump when the embedded payload shape changes. */
+export const EXPORT_FORMAT_VERSION = 1;
+
+/** Default zoom level when none is supplied. */
+const DEFAULT_ZOOM: ZoomLevel = 'month';
+
+/** Default lane grouping when none is supplied. */
+const DEFAULT_GROUP_BY: LaneGroupBy = 'lane';
+
+/**
+ * Timeline layout config used for the artifact. Mirrors the in-app defaults
+ * (see `useTimelineData`) so positioning matches the canvas. `canvasWidth` is
+ * computed per export from the date range + zoom level.
+ */
+const BASE_CONFIG: Omit<TimelineConfig, 'canvasWidth'> = {
+  canvasHeight: 600,
+  margin: { top: 60, right: 20, bottom: 20, left: 150 },
+  laneHeight: 50,
+  itemPadding: 4,
+  itemHeight: 36,
+};
+
+// ---------------------------------------------------------------------------
+// Filtering
+// ---------------------------------------------------------------------------
+
+/**
+ * Filters items the same way the in-app timeline does (type exact match,
+ * project partial case-insensitive, date-range overlap).
+ *
+ * @param items - Items to filter
+ * @param filters - Active filters (empty/undefined fields are ignored)
+ * @returns Filtered items
+ */
+export function filterItems(items: Item[], filters: ExportFilters = {}): Item[] {
+  const { type, project, startDate, endDate } = filters;
+
+  return items.filter((item) => {
+    if (type && item.type !== type) return false;
+
+    if (project && !item.project?.toLowerCase().includes(project.toLowerCase())) return false;
+
+    // Item must end on or after the filter start date
+    if (startDate && item.end_date && item.end_date < startDate) return false;
+
+    // Item must start on or before the filter end date
+    if (endDate && item.start_date && item.start_date > endDate) return false;
+
+    return true;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Render model
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds the pure, serializable render model for a set of items.
+ *
+ * @param items - Items to render (already filtered)
+ * @param zoomLevel - Zoom level for layout
+ * @param laneGroupBy - Lane grouping strategy
+ * @returns Render model with config, lanes, ticks, and SVG dimensions
+ */
+export function buildRenderModel(
+  items: Item[],
+  zoomLevel: ZoomLevel = DEFAULT_ZOOM,
+  laneGroupBy: LaneGroupBy = DEFAULT_GROUP_BY
+): ExportRenderModel {
+  const dateRange = calculateDateRange(items);
+  const chartWidth = calculateChartWidth(dateRange, zoomLevel);
+
+  const config: TimelineConfig = {
+    ...BASE_CONFIG,
+    canvasWidth: chartWidth,
+  };
+
+  const laneData = groupItemsByLane(items, laneGroupBy);
+  const laneGroups = createLaneGroups(laneData, config);
+  const timeAxisTicks = calculateTimeAxisTicks(dateRange, zoomLevel, config);
+
+  const totalLaneHeight = laneGroups.reduce((sum, group) => sum + group.height, 0);
+  const svgWidth = config.canvasWidth;
+  const svgHeight = config.margin.top + totalLaneHeight + config.margin.bottom;
+
+  return { config, dateRange, laneGroups, timeAxisTicks, svgWidth, svgHeight };
+}
+
+// ---------------------------------------------------------------------------
+// String escaping
+// ---------------------------------------------------------------------------
+
+/** Escapes text for safe inclusion in XML/SVG/HTML text and attribute values. */
+export function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/** Escapes a JSON string so it can be embedded inside a <script> tag safely. */
+function escapeForScript(json: string): string {
+  // Prevent a literal </script> in the data from terminating the tag, and
+  // neutralize HTML-comment / line-separator edge cases.
+  return json
+    .replace(/<\/script/gi, '<\\/script')
+    .replace(/<!--/g, '<\\!--')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
+/**
+ * Truncates text to roughly fit a pixel width, appending an ellipsis.
+ * SVG has no native text truncation, so this is an approximation.
+ */
+function truncateToWidth(text: string, maxPx: number, pxPerChar: number): string {
+  if (maxPx <= 0) return '';
+  const maxChars = Math.floor(maxPx / pxPerChar);
+  if (text.length <= maxChars) return text;
+  if (maxChars <= 1) return '…';
+  return text.slice(0, maxChars - 1) + '…';
+}
+
+// ---------------------------------------------------------------------------
+// SVG rendering
+// ---------------------------------------------------------------------------
+
+/** Builds the multi-line hover tooltip text for an item (one item per `<title>`). */
+function itemTooltip(item: Item): string {
+  const lines: string[] = [`${item.title} (${item.type})`];
+  if (item.start_date) lines.push(`Start: ${item.start_date}`);
+  if (item.end_date && item.type !== 'milestone') lines.push(`End: ${item.end_date}`);
+  if (item.owner) lines.push(`Owner: ${item.owner}`);
+  if (item.project) lines.push(`Project: ${item.project}`);
+  if (item.lane) lines.push(`Lane: ${item.lane}`);
+  if (item.tags) lines.push(`Tags: ${item.tags}`);
+  return escapeXml(lines.join('\n'));
+}
+
+/**
+ * Renders the timeline render model to an SVG string.
+ *
+ * Visual encoding matches the app: tasks=blue, milestones=green diamonds,
+ * releases=orange, meetings=purple. Lanes alternate background shades, with
+ * fixed lane labels on the left and a time axis across the top.
+ *
+ * @param model - Render model from {@link buildRenderModel}
+ * @returns Standalone `<svg>...</svg>` markup
+ */
+export function renderSvg(model: ExportRenderModel): string {
+  const { config, dateRange, laneGroups, timeAxisTicks, svgWidth, svgHeight } = model;
+  const { margin } = config;
+
+  const parts: string[] = [];
+  parts.push(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${svgWidth}" height="${svgHeight}" ` +
+      `viewBox="0 0 ${svgWidth} ${svgHeight}" font-family="-apple-system, system-ui, sans-serif">`
+  );
+
+  // Empty state
+  if (laneGroups.length === 0 || !dateRange.minDate) {
+    parts.push(
+      `<text x="${svgWidth / 2}" y="${svgHeight / 2}" text-anchor="middle" ` +
+        `font-size="16" fill="#6b7280">No dated items to display</text>`
+    );
+    parts.push('</svg>');
+    return parts.join('\n');
+  }
+
+  // --- Layer 1: lane backgrounds (alternating shades) ---
+  let cumulativeY = margin.top;
+  const laneTops: number[] = [];
+  laneGroups.forEach((lane, index) => {
+    laneTops.push(cumulativeY);
+    const fill = index % 2 === 0 ? '#e5e7eb' : '#ffffff';
+    parts.push(
+      `<rect x="0" y="${cumulativeY}" width="${svgWidth}" height="${lane.height}" fill="${fill}"/>`
+    );
+    cumulativeY += lane.height;
+  });
+
+  // --- Layer 2: items ---
+  laneGroups.forEach((lane, laneIndex) => {
+    const laneTop = laneTops[laneIndex] ?? margin.top;
+    const rowMap = assignItemRows(lane.items);
+
+    lane.items.forEach((item) => {
+      const pos = calculateItemPosition(item, dateRange, 0, config);
+      if (!pos) return;
+
+      const rowIndex = rowMap.get(item.id) ?? 0;
+      const itemY =
+        laneTop + config.itemPadding + rowIndex * (config.itemHeight + config.itemPadding);
+      const color = DEFAULT_ITEM_COLORS[item.type];
+      const tooltip = itemTooltip(item);
+
+      if (item.type === 'milestone') {
+        // Diamond centered on the start date
+        const cx = pos.x + pos.width / 2;
+        const cy = itemY + pos.height / 2;
+        const r = pos.height / 2;
+        const points = `${cx},${cy - r} ${cx + r},${cy} ${cx},${cy + r} ${cx - r},${cy}`;
+        parts.push(
+          `<g><title>${tooltip}</title>` +
+            `<polygon points="${points}" fill="${color}" stroke="${color}" ` +
+            `stroke-width="2" opacity="0.85"/>` +
+            `<text x="${cx + r + 8}" y="${cy}" dominant-baseline="middle" ` +
+            `font-size="11" fill="#374151">${escapeXml(item.title)}</text>` +
+            `</g>`
+        );
+      } else {
+        // Bar for task / release / meeting
+        const label =
+          pos.width > 50
+            ? `<text x="${pos.x + 6}" y="${itemY + pos.height / 2}" dominant-baseline="middle" ` +
+              `font-size="11" font-weight="bold" fill="#ffffff">` +
+              `${escapeXml(truncateToWidth(item.title, pos.width - 12, 6.2))}</text>`
+            : '';
+        parts.push(
+          `<g><title>${tooltip}</title>` +
+            `<rect x="${pos.x}" y="${itemY}" width="${pos.width}" height="${pos.height}" ` +
+            `rx="4" fill="${color}" opacity="0.9"/>` +
+            label +
+            `</g>`
+        );
+      }
+    });
+  });
+
+  // --- Layer 3: time axis (white strip across the top, drawn over item tops) ---
+  parts.push(`<rect x="0" y="0" width="${svgWidth}" height="${margin.top}" fill="#ffffff"/>`);
+  timeAxisTicks.forEach((tick) => {
+    const stroke = tick.isMajor ? '#333333' : '#999999';
+    const strokeWidth = tick.isMajor ? 2 : 1;
+    parts.push(
+      `<line x1="${tick.x}" y1="${margin.top - 10}" x2="${tick.x}" y2="${margin.top}" ` +
+        `stroke="${stroke}" stroke-width="${strokeWidth}"/>`
+    );
+    parts.push(
+      `<text x="${tick.x}" y="${margin.top - 16}" text-anchor="middle" font-size="12" ` +
+        `fill="#333333">${escapeXml(tick.label)}</text>`
+    );
+  });
+  parts.push(
+    `<line x1="0" y1="${margin.top}" x2="${svgWidth}" y2="${margin.top}" ` +
+      `stroke="#333333" stroke-width="2"/>`
+  );
+
+  // --- Layer 4: lane labels (white strip down the left, drawn over item starts) ---
+  laneGroups.forEach((lane, index) => {
+    const top = laneTops[index] ?? margin.top;
+    const centerY = top + lane.height / 2;
+    parts.push(
+      `<rect x="0" y="${top}" width="${margin.left}" height="${lane.height}" ` +
+        `fill="#ffffff" opacity="0.97"/>`
+    );
+    const labelText = truncateToWidth(lane.laneName, margin.left - 20, 7.5);
+    parts.push(
+      `<text x="10" y="${centerY}" dominant-baseline="middle" font-size="14" ` +
+        `font-weight="bold" fill="#4b5563"><title>${escapeXml(lane.laneName)}</title>` +
+        `${escapeXml(labelText)}</text>`
+    );
+  });
+
+  parts.push('</svg>');
+  return parts.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// HTML document
+// ---------------------------------------------------------------------------
+
+/** Human-readable summary of the active filters for the header. */
+function describeFilters(filters: ExportFilters): string {
+  const parts: string[] = [];
+  if (filters.type) parts.push(`type=${filters.type}`);
+  if (filters.project) parts.push(`project~"${filters.project}"`);
+  if (filters.startDate) parts.push(`from ${filters.startDate}`);
+  if (filters.endDate) parts.push(`to ${filters.endDate}`);
+  return parts.length > 0 ? parts.join(', ') : 'none';
+}
+
+/**
+ * Generates the complete self-contained HTML artifact for one or more branches.
+ *
+ * v1 renders the active branch's timeline as inline SVG and embeds every
+ * provided branch's data as JSON (for v2 to consume). No external requests,
+ * no runtime dependencies.
+ *
+ * @param branches - Branch data to bake in (v1 callers pass one)
+ * @param options - Export options (active branch, zoom, grouping, filters, title)
+ * @returns A full HTML document string
+ * @throws If the active branch is not present in `branches`
+ */
+export function generateTimelineArtifact(
+  branches: ExportBranchInput[],
+  options: ExportOptions
+): string {
+  const zoomLevel = options.zoomLevel ?? DEFAULT_ZOOM;
+  const laneGroupBy = options.laneGroupBy ?? DEFAULT_GROUP_BY;
+  const filters = options.filters ?? {};
+  const generatedAt = options.generatedAt ?? new Date();
+
+  const active = branches.find((b) => b.branchId === options.activeBranchId);
+  if (!active) {
+    throw new Error(`Active branch "${options.activeBranchId}" not found among provided branches`);
+  }
+
+  const activeLabel = active.label || active.branchId;
+  const title = options.title || `SwimLanes Timeline — ${activeLabel}`;
+
+  // Filter then render the active branch.
+  const filteredActiveItems = filterItems(active.items, filters);
+  const model = buildRenderModel(filteredActiveItems, zoomLevel, laneGroupBy);
+  const svg = renderSvg(model);
+
+  // Build the N-branch payload (each branch's items pre-filtered for v2 reuse).
+  const payload: ExportPayload = {
+    formatVersion: EXPORT_FORMAT_VERSION,
+    title,
+    generatedAt: generatedAt.toISOString(),
+    zoomLevel,
+    laneGroupBy,
+    filters,
+    activeBranchId: options.activeBranchId,
+    branches: branches.map((b) => ({
+      branchId: b.branchId,
+      label: b.label ?? null,
+      items: filterItems(b.items, filters),
+    })),
+  };
+  const payloadJson = escapeForScript(JSON.stringify(payload));
+
+  const itemCount = filteredActiveItems.length;
+  const generatedDisplay = generatedAt.toLocaleString();
+  const filterSummary = describeFilters(filters);
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<meta name="generator" content="SwimLanes"/>
+<title>${escapeXml(title)}</title>
+<style>
+  :root { color-scheme: light; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, system-ui, sans-serif;
+    color: #1f2937;
+    background: #f9fafb;
+  }
+  header {
+    padding: 16px 20px;
+    background: #ffffff;
+    border-bottom: 1px solid #e5e7eb;
+  }
+  header h1 { margin: 0 0 4px; font-size: 18px; }
+  header .meta { font-size: 12px; color: #6b7280; }
+  header .meta span { margin-right: 16px; white-space: nowrap; }
+  .legend { margin-top: 8px; font-size: 12px; color: #4b5563; }
+  .legend .swatch {
+    display: inline-block; width: 10px; height: 10px; border-radius: 2px;
+    margin: 0 4px 0 12px; vertical-align: middle;
+  }
+  .legend .swatch:first-child { margin-left: 0; }
+  .timeline-scroll { overflow: auto; padding: 16px 20px 40px; }
+  .timeline-scroll svg { background: #ffffff; border: 1px solid #e5e7eb; border-radius: 8px; }
+</style>
+</head>
+<body>
+<header>
+  <h1>${escapeXml(title)}</h1>
+  <div class="meta">
+    <span>Branch: <strong>${escapeXml(activeLabel)}</strong></span>
+    <span>Items: <strong>${itemCount}</strong></span>
+    <span>Zoom: ${escapeXml(zoomLevel)}</span>
+    <span>Grouped by: ${escapeXml(laneGroupBy)}</span>
+    <span>Filters: ${escapeXml(filterSummary)}</span>
+    <span>Generated: ${escapeXml(generatedDisplay)}</span>
+  </div>
+  <div class="legend">
+    <span class="swatch" style="background:${DEFAULT_ITEM_COLORS.task}"></span>Task
+    <span class="swatch" style="background:${DEFAULT_ITEM_COLORS.milestone}"></span>Milestone
+    <span class="swatch" style="background:${DEFAULT_ITEM_COLORS.release}"></span>Release
+    <span class="swatch" style="background:${DEFAULT_ITEM_COLORS.meeting}"></span>Meeting
+  </div>
+</header>
+<main class="timeline-scroll">
+${svg}
+</main>
+<script type="application/json" id="swimlanes-data">
+${payloadJson}
+</script>
+</body>
+</html>`;
+}

--- a/src/services/export.service.ts
+++ b/src/services/export.service.ts
@@ -414,8 +414,9 @@ function emptySvg(width: number, height: number): string {
 
 /**
  * Renders the full timeline model to a single self-contained SVG (chart + lane
- * labels together). Used standalone; the artifact uses {@link renderChartSvg} +
- * {@link renderGutterSvg} for a frozen label column.
+ * labels + axis together). Used standalone; the artifact uses the four quadrant
+ * panes ({@link renderCornerSvg}, {@link renderAxisSvg}, {@link renderLabelsSvg},
+ * {@link renderBodySvg}) so both the labels and the axis stay frozen.
  *
  * @param model - Render model from {@link buildRenderModel}
  * @param options - Optional render options (e.g. today marker)
@@ -436,48 +437,82 @@ export function renderSvg(model: ExportRenderModel, options: RenderSvgOptions = 
   ]);
 }
 
-/**
- * Renders the scrollable chart (everything except the left lane-label column).
- * The viewBox crops the left margin so x=0 begins at the chart area, letting a
- * separate frozen gutter ({@link renderGutterSvg}) sit to its left.
- */
-export function renderChartSvg(model: ExportRenderModel, options: RenderSvgOptions = {}): string {
-  const { svgWidth, svgHeight, laneGroups, dateRange, config } = model;
-  const chartWidth = Math.max(svgWidth - config.margin.left, 1);
-  if (laneGroups.length === 0 || !dateRange.minDate) return emptySvg(chartWidth, svgHeight);
+/** Chart content width (timeline area, excluding the left label margin). */
+function chartContentWidth(model: ExportRenderModel): number {
+  return Math.max(model.svgWidth - model.config.margin.left, 1);
+}
 
-  const { laneTops, positioned, posMap } = computeLayout(model);
-  const viewBox = `${config.margin.left} 0 ${chartWidth} ${svgHeight}`;
-  return svgWrap(chartWidth, svgHeight, viewBox, [
-    depArrowDefs(),
-    ...emitBackgrounds(model, laneTops, svgWidth),
-    ...emitTodayMarker(model, options.nowDate),
-    ...emitArrows(positioned, posMap),
-    ...emitItems(positioned),
-    ...emitAxis(model, svgWidth),
+/** Body height (timeline rows, excluding the top axis margin). */
+function bodyHeight(model: ExportRenderModel): number {
+  return Math.max(model.svgHeight - model.config.margin.top, 1);
+}
+
+/**
+ * Top-left corner pane (frozen on both axes). Zoom-independent: just the corner
+ * fill and a "Lanes" caption aligned with the axis.
+ */
+export function renderCornerSvg(model: ExportRenderModel): string {
+  const { config } = model;
+  const w = config.margin.left;
+  const h = config.margin.top;
+  return svgWrap(w, h, `0 0 ${w} ${h}`, [
+    `<rect class="axis-strip" x="0" y="0" width="${w}" height="${h}"/>`,
+    `<text class="lane-corner" x="10" y="${h - 16}" font-size="11">Lanes</text>`,
   ]);
 }
 
 /**
- * Renders the frozen left gutter: alternating lane backgrounds, the top-left
- * corner, and the lane labels. Stays fixed while the chart scrolls.
+ * Time-axis pane (frozen vertically, scrolls horizontally with the body).
+ * viewBox crops to the top strip, right of the label margin.
  */
-export function renderGutterSvg(model: ExportRenderModel): string {
-  const { svgHeight, laneGroups, dateRange, config } = model;
-  const width = config.margin.left;
+export function renderAxisSvg(model: ExportRenderModel): string {
+  const { laneGroups, dateRange, config } = model;
+  const w = chartContentWidth(model);
+  const h = config.margin.top;
   if (laneGroups.length === 0 || !dateRange.minDate) {
-    return svgWrap(width, svgHeight, `0 0 ${width} ${svgHeight}`, [
-      `<rect class="axis-strip" x="0" y="0" width="${width}" height="${svgHeight}"/>`,
+    return svgWrap(w, h, `${config.margin.left} 0 ${w} ${h}`, [
+      `<rect class="axis-strip" x="${config.margin.left}" y="0" width="${w}" height="${h}"/>`,
     ]);
   }
+  return svgWrap(w, h, `${config.margin.left} 0 ${w} ${h}`, emitAxis(model, model.svgWidth));
+}
 
+/**
+ * Lane-labels pane (frozen horizontally, scrolls vertically with the body).
+ * Zoom-independent. viewBox crops to the left margin, below the axis.
+ */
+export function renderLabelsSvg(model: ExportRenderModel): string {
+  const { laneGroups, dateRange, config } = model;
+  const w = config.margin.left;
+  const h = bodyHeight(model);
+  if (laneGroups.length === 0 || !dateRange.minDate) {
+    return svgWrap(w, h, `0 ${config.margin.top} ${w} ${h}`, []);
+  }
   const { laneTops } = computeLayout(model);
-  return svgWrap(width, svgHeight, `0 0 ${width} ${svgHeight}`, [
-    ...emitBackgrounds(model, laneTops, width),
+  return svgWrap(w, h, `0 ${config.margin.top} ${w} ${h}`, [
+    ...emitBackgrounds(model, laneTops, w),
     ...emitLaneLabels(model, laneTops),
-    // Top-left corner over the lane backgrounds, aligned with the time axis.
-    `<rect class="axis-strip" x="0" y="0" width="${width}" height="${config.margin.top}"/>`,
-    `<text class="lane-corner" x="10" y="${config.margin.top - 16}" font-size="11">Lanes</text>`,
+  ]);
+}
+
+/**
+ * Body pane: lane backgrounds, dependency arrows, items, and the Today marker.
+ * Scrolls on both axes. viewBox crops out the label margin and axis strip.
+ */
+export function renderBodySvg(model: ExportRenderModel, options: RenderSvgOptions = {}): string {
+  const { laneGroups, dateRange, config } = model;
+  const w = chartContentWidth(model);
+  const h = bodyHeight(model);
+  if (laneGroups.length === 0 || !dateRange.minDate) return emptySvg(w, h);
+
+  const { laneTops, positioned, posMap } = computeLayout(model);
+  const viewBox = `${config.margin.left} ${config.margin.top} ${w} ${h}`;
+  return svgWrap(w, h, viewBox, [
+    depArrowDefs(),
+    ...emitBackgrounds(model, laneTops, model.svgWidth),
+    ...emitTodayMarker(model, options.nowDate),
+    ...emitArrows(positioned, posMap),
+    ...emitItems(positioned),
   ]);
 }
 
@@ -500,8 +535,77 @@ interface RenderedBranch {
   branchId: string;
   label: string;
   itemCount: number;
-  gutterSvg: string;
-  chartSvg: string;
+  /** Frozen-corner pane (zoom-independent). */
+  cornerSvg: string;
+  /** Frozen lane-labels pane (zoom-independent). */
+  labelsSvg: string;
+  /** Per-zoom axis + body panes. */
+  charts: { zoom: ZoomLevel; axisSvg: string; bodySvg: string }[];
+}
+
+const ZOOM_LABELS: Record<ZoomLevel, string> = {
+  day: 'Day',
+  week: 'Week',
+  month: 'Month',
+  quarter: 'Quarter',
+  year: 'Year',
+};
+
+/** Default zoom levels baked into the artifact (day excluded to limit size). */
+const DEFAULT_ZOOM_LEVELS: ZoomLevel[] = ['week', 'month', 'quarter', 'year'];
+
+/** Orders/dedupes requested zoom levels into the canonical day→year order. */
+function resolveZoomLevels(requested: ZoomLevel[], active: ZoomLevel): ZoomLevel[] {
+  const order: ZoomLevel[] = ['day', 'week', 'month', 'quarter', 'year'];
+  const wanted = new Set<ZoomLevel>([...requested, active]);
+  return order.filter((z) => wanted.has(z));
+}
+
+/**
+ * Builds the zoom switcher markup (one button per baked zoom level). Returns an
+ * empty string when only one zoom is baked.
+ */
+function renderZoomSwitcher(zoomLevels: ZoomLevel[], activeZoom: ZoomLevel): string {
+  if (zoomLevels.length <= 1) return '';
+  const buttons = zoomLevels
+    .map((z) => {
+      const on = z === activeZoom;
+      return (
+        `<button type="button" class="zoom-btn${on ? ' active' : ''}" data-zoom="${z}" ` +
+        `aria-pressed="${on ? 'true' : 'false'}">${ZOOM_LABELS[z]}</button>`
+      );
+    })
+    .join('\n    ');
+  return `<div class="zoom-switcher" role="group" aria-label="Zoom">
+    <span class="switcher-label">Zoom:</span>
+    ${buttons}
+  </div>`;
+}
+
+/**
+ * Runtime script that switches which zoom's panes are visible across all branch
+ * views and keeps the header in sync. Only emitted when >1 zoom is baked.
+ */
+function renderZoomScript(): string {
+  return `<script>
+(function () {
+  var panes = document.querySelectorAll('.zoom-pane');
+  var btns = document.querySelectorAll('.zoom-btn');
+  var metaZoom = document.getElementById('meta-zoom');
+  function activate(zoom) {
+    panes.forEach(function (p) { p.hidden = p.getAttribute('data-zoom') !== zoom; });
+    btns.forEach(function (b) {
+      var on = b.getAttribute('data-zoom') === zoom;
+      b.classList.toggle('active', on);
+      b.setAttribute('aria-pressed', on ? 'true' : 'false');
+    });
+    if (metaZoom) metaZoom.textContent = zoom;
+  }
+  btns.forEach(function (b) {
+    b.addEventListener('click', function () { activate(b.getAttribute('data-zoom')); });
+  });
+})();
+</script>`;
 }
 
 /**
@@ -602,6 +706,7 @@ export function generateTimelineArtifact(
   const laneGroupBy = options.laneGroupBy ?? DEFAULT_GROUP_BY;
   const filters = options.filters ?? {};
   const generatedAt = options.generatedAt ?? new Date();
+  const zoomLevels = resolveZoomLevels(options.zoomLevels ?? DEFAULT_ZOOM_LEVELS, zoomLevel);
 
   const active = branches.find((b) => b.branchId === options.activeBranchId);
   if (!active) {
@@ -614,29 +719,47 @@ export function generateTimelineArtifact(
   // "Today" marker date (the generation date), drawn if within a branch's range.
   const nowDate = generatedAt.toISOString().split('T')[0];
 
-  // Filter + render every branch (active shown initially, the rest hidden).
+  // Filter + render every branch at every baked zoom level. Lane structure is
+  // zoom-independent, so corner/labels are rendered once (from the active zoom).
   const rendered: RenderedBranch[] = branches.map((b) => {
     const items = filterItems(b.items, filters);
-    const model = buildRenderModel(items, zoomLevel, laneGroupBy);
+    const baseModel = buildRenderModel(items, zoomLevel, laneGroupBy);
     return {
       branchId: b.branchId,
       label: b.label || b.branchId,
       itemCount: items.length,
-      gutterSvg: renderGutterSvg(model),
-      chartSvg: renderChartSvg(model, { nowDate }),
+      cornerSvg: renderCornerSvg(baseModel),
+      labelsSvg: renderLabelsSvg(baseModel),
+      charts: zoomLevels.map((zoom) => {
+        const model = buildRenderModel(items, zoom, laneGroupBy);
+        return { zoom, axisSvg: renderAxisSvg(model), bodySvg: renderBodySvg(model, { nowDate }) };
+      }),
     };
   });
 
   const activeBranchId = options.activeBranchId;
   const activeRendered = rendered.find((r) => r.branchId === activeBranchId)!;
 
+  const zoomPane = (zoom: ZoomLevel, cls: string, svg: string): string => {
+    const hidden = zoom === zoomLevel ? '' : ' hidden';
+    return `<div class="zoom-pane ${cls}" data-zoom="${zoom}"${hidden}>${svg}</div>`;
+  };
+
   const branchViews = rendered
     .map((r) => {
       const hidden = r.branchId === activeBranchId ? '' : ' hidden';
+      const axisPanes = r.charts.map((c) => zoomPane(c.zoom, 'axis-pane', c.axisSvg)).join('');
+      const bodyPanes = r.charts.map((c) => zoomPane(c.zoom, 'body-pane', c.bodySvg)).join('');
       return `<section class="branch-view" data-branch-id="${escapeXml(r.branchId)}"${hidden}>
   <div class="timeline-frame">
-    <div class="lane-gutter">${r.gutterSvg}</div>
-    <div class="timeline-scroll">${r.chartSvg}</div>
+    <div class="timeline-viewport">
+      <div class="timeline-grid">
+        <div class="corner">${r.cornerSvg}</div>
+        <div class="axis-col">${axisPanes}</div>
+        <div class="labels-col">${r.labelsSvg}</div>
+        <div class="body-col">${bodyPanes}</div>
+      </div>
+    </div>
   </div>
 </section>`;
     })
@@ -644,6 +767,8 @@ export function generateTimelineArtifact(
 
   const switcher = renderSwitcher(rendered, activeBranchId);
   const switcherScript = rendered.length > 1 ? renderSwitcherScript() : '';
+  const zoomSwitcher = renderZoomSwitcher(zoomLevels, zoomLevel);
+  const zoomScript = zoomLevels.length > 1 ? renderZoomScript() : '';
 
   // Build the N-branch payload (each branch's items pre-filtered).
   const payload: ExportPayload = {
@@ -740,20 +865,39 @@ export function generateTimelineArtifact(
     font-size: 11px; text-align: center; border-radius: 9px; background: var(--count-bg);
   }
   .scenario-btn.active .count { background: rgba(255, 255, 255, 0.25); }
-  .branch-view[hidden] { display: none; }
-  /* Frozen lane-label gutter + scrollable chart */
-  .timeline-frame {
-    display: flex; align-items: flex-start; margin: 16px 20px 40px;
-    border: 1px solid var(--border); border-radius: 8px; overflow: hidden;
-    background: var(--svg-bg);
+  /* Zoom switcher reuses the scenario button styles */
+  .zoom-switcher {
+    display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
+    padding: 10px 20px; background: var(--panel); border-bottom: 1px solid var(--border);
   }
-  .lane-gutter { flex: 0 0 auto; border-right: 1px solid var(--border); }
-  .timeline-scroll { flex: 1 1 auto; min-width: 0; overflow-x: auto; overflow-y: hidden; }
-  .lane-gutter svg, .timeline-scroll svg { display: block; }
+  .zoom-switcher .switcher-label {
+    font-size: 12px; font-weight: 600; color: var(--muted); margin-right: 4px;
+  }
+  .zoom-btn {
+    font: inherit; font-size: 13px; padding: 6px 12px; border: 1px solid var(--btn-border);
+    border-radius: 6px; background: var(--btn-bg); color: var(--btn-text); cursor: pointer;
+  }
+  .zoom-btn:hover { background: var(--btn-hover); }
+  .zoom-btn.active { background: var(--accent); border-color: var(--accent); color: var(--accent-text); }
+  .branch-view[hidden] { display: none; }
+  /* Frozen-pane timeline: corner + axis (top) + labels (left) + body */
+  .timeline-frame {
+    margin: 16px 20px 40px; border: 1px solid var(--border); border-radius: 8px;
+    overflow: hidden; background: var(--svg-bg);
+  }
+  .timeline-viewport { overflow: auto; max-height: 72vh; }
+  .timeline-grid { display: grid; grid-template-columns: auto auto; grid-template-rows: auto auto; width: max-content; }
+  .timeline-grid > div { background: var(--svg-bg); }
+  .corner { position: sticky; top: 0; left: 0; z-index: 4; border-right: 1px solid var(--border); border-bottom: 1px solid var(--border); }
+  .axis-col { position: sticky; top: 0; z-index: 3; border-bottom: 1px solid var(--border); }
+  .labels-col { position: sticky; left: 0; z-index: 2; border-right: 1px solid var(--border); }
+  .body-col { z-index: 1; }
+  .timeline-grid svg { display: block; }
+  .zoom-pane[hidden] { display: none; }
   .lane-corner { fill: var(--muted); font-weight: 600; }
   .today-line { stroke: var(--accent); stroke-width: 1.5; stroke-dasharray: 4 3; opacity: 0.85; }
   .today-label { fill: var(--accent); font-weight: 600; }
-  .timeline-scroll g:hover rect, .timeline-scroll g:hover polygon { opacity: 1; }
+  .body-col g:hover rect, .body-col g:hover polygon { opacity: 1; }
   /* Theme-able SVG chrome */
   .lane-bg-even { fill: var(--lane-even); }
   .lane-bg-odd { fill: var(--lane-odd); }
@@ -770,8 +914,9 @@ export function generateTimelineArtifact(
   @media print {
     body { background: #ffffff; }
     .no-print { display: none !important; }
-    .timeline-frame { overflow: visible; max-width: none; }
-    .timeline-scroll { overflow: visible; }
+    .timeline-frame { overflow: visible; }
+    .timeline-viewport { overflow: visible; max-height: none; }
+    .corner, .axis-col, .labels-col { position: static; }
     @page { size: landscape; margin: 1cm; }
   }
 </style>
@@ -783,7 +928,7 @@ export function generateTimelineArtifact(
     <div class="meta">
       <span>Branch: <strong id="meta-branch">${escapeXml(activeLabel)}</strong></span>
       <span>Items: <strong id="meta-items">${itemCount}</strong></span>
-      <span>Zoom: ${escapeXml(zoomLevel)}</span>
+      <span>Zoom: <strong id="meta-zoom">${escapeXml(zoomLevel)}</strong></span>
       <span>Grouped by: ${escapeXml(laneGroupBy)}</span>
       <span>Filters: ${escapeXml(filterSummary)}</span>
       <span>Generated: ${escapeXml(generatedDisplay)}</span>
@@ -800,6 +945,7 @@ export function generateTimelineArtifact(
   </button>
 </header>
 ${switcher}
+${zoomSwitcher}
 <main>
 ${branchViews}
 </main>
@@ -809,6 +955,7 @@ ${payloadJson}
 </script>
 ${renderThemeScript()}
 ${switcherScript}
+${zoomScript}
 </body>
 </html>`;
 }

--- a/src/services/export.service.ts
+++ b/src/services/export.service.ts
@@ -204,65 +204,29 @@ interface PositionedItem {
   color: string;
 }
 
-/**
- * Renders the timeline render model to an SVG string.
- *
- * Visual encoding matches the app: tasks=blue, milestones=green diamonds,
- * releases=orange, meetings=purple. Lanes alternate background shades, with
- * fixed lane labels on the left and a time axis across the top. Dependency
- * arrows connect items whose `dependencies` reference another visible item.
- *
- * Theme-able chrome (backgrounds, axis, labels) is emitted with CSS classes so
- * the surrounding document can recolor it for light/dark; item/brand colors
- * stay inline. See {@link generateTimelineArtifact} for the class definitions.
- *
- * @param model - Render model from {@link buildRenderModel}
- * @returns Standalone `<svg>...</svg>` markup
- */
-export function renderSvg(model: ExportRenderModel): string {
-  const { config, dateRange, laneGroups, timeAxisTicks, svgWidth, svgHeight } = model;
+/** Options shared by the SVG renderers. */
+export interface RenderSvgOptions {
+  /** If set (ISO YYYY-MM-DD) and within range, draws a "Today" marker line. */
+  nowDate?: string;
+}
+
+/** Computes lane tops and positioned items for a model. */
+function computeLayout(model: ExportRenderModel): {
+  laneTops: number[];
+  positioned: PositionedItem[];
+  posMap: Map<string, PositionedItem>;
+} {
+  const { config, dateRange, laneGroups } = model;
   const { margin } = config;
 
-  const parts: string[] = [];
-  parts.push(
-    `<svg xmlns="http://www.w3.org/2000/svg" width="${svgWidth}" height="${svgHeight}" ` +
-      `viewBox="0 0 ${svgWidth} ${svgHeight}" font-family="-apple-system, system-ui, sans-serif">`
-  );
-
-  // Empty state
-  if (laneGroups.length === 0 || !dateRange.minDate) {
-    parts.push(
-      `<text class="empty-msg" x="${svgWidth / 2}" y="${svgHeight / 2}" text-anchor="middle" ` +
-        `font-size="16">No dated items to display</text>`
-    );
-    parts.push('</svg>');
-    return parts.join('\n');
-  }
-
-  // Arrowhead marker for dependency connectors.
-  parts.push(
-    `<defs><marker id="dep-arrowhead" markerWidth="8" markerHeight="8" refX="7" refY="4" ` +
-      `orient="auto" markerUnits="userSpaceOnUse">` +
-      `<path d="M0,0 L8,4 L0,8 z" fill="#6b7280"/></marker></defs>`
-  );
-
-  // --- Layer 1: lane backgrounds (alternating shades) ---
   let cumulativeY = margin.top;
   const laneTops: number[] = [];
-  laneGroups.forEach((lane, index) => {
-    laneTops.push(cumulativeY);
-    const cls = index % 2 === 0 ? 'lane-bg-even' : 'lane-bg-odd';
-    parts.push(
-      `<rect class="${cls}" x="0" y="${cumulativeY}" width="${svgWidth}" height="${lane.height}"/>`
-    );
-    cumulativeY += lane.height;
-  });
-
-  // --- Pass: compute positions for every item (for arrows + drawing) ---
   const positioned: PositionedItem[] = [];
   const posMap = new Map<string, PositionedItem>();
+
   laneGroups.forEach((lane, laneIndex) => {
-    const laneTop = laneTops[laneIndex] ?? margin.top;
+    laneTops[laneIndex] = cumulativeY;
+    const laneTop = cumulativeY;
     const rowMap = assignItemRows(lane.items);
 
     lane.items.forEach((item) => {
@@ -273,7 +237,6 @@ export function renderSvg(model: ExportRenderModel): string {
       const itemY =
         laneTop + config.itemPadding + rowIndex * (config.itemHeight + config.itemPadding);
       const isMilestone = item.type === 'milestone';
-      const centerY = itemY + pos.height / 2;
       const r = pos.height / 2;
       const cx = pos.x + pos.width / 2;
 
@@ -282,7 +245,7 @@ export function renderSvg(model: ExportRenderModel): string {
         isMilestone,
         startX: isMilestone ? cx - r : pos.x,
         endX: isMilestone ? cx + r : pos.x + pos.width,
-        centerY,
+        centerY: itemY + pos.height / 2,
         x: pos.x,
         y: itemY,
         width: pos.width,
@@ -293,9 +256,33 @@ export function renderSvg(model: ExportRenderModel): string {
       // Last writer wins on duplicate ids; fine for arrow anchoring.
       posMap.set(item.id, entry);
     });
+
+    cumulativeY += lane.height;
   });
 
-  // --- Layer 2: dependency arrows (under items, so bars sit on top) ---
+  return { laneTops, positioned, posMap };
+}
+
+/** Marker def for dependency arrowheads. */
+function depArrowDefs(): string {
+  return (
+    `<defs><marker id="dep-arrowhead" markerWidth="8" markerHeight="8" refX="7" refY="4" ` +
+    `orient="auto" markerUnits="userSpaceOnUse">` +
+    `<path d="M0,0 L8,4 L0,8 z" fill="#6b7280"/></marker></defs>`
+  );
+}
+
+/** Emits alternating lane background rects spanning [0, width]. */
+function emitBackgrounds(model: ExportRenderModel, laneTops: number[], width: number): string[] {
+  return model.laneGroups.map((lane, index) => {
+    const cls = index % 2 === 0 ? 'lane-bg-even' : 'lane-bg-odd';
+    return `<rect class="${cls}" x="0" y="${laneTops[index]}" width="${width}" height="${lane.height}"/>`;
+  });
+}
+
+/** Emits dependency arrow paths between positioned items. */
+function emitArrows(positioned: PositionedItem[], posMap: Map<string, PositionedItem>): string[] {
+  const out: string[] = [];
   positioned.forEach((target) => {
     parseDependencies(target.item.dependencies).forEach((depId) => {
       const source = posMap.get(depId);
@@ -305,80 +292,193 @@ export function renderSvg(model: ExportRenderModel): string {
       const tx = target.startX;
       const ty = target.centerY;
       const dx = Math.max(16, Math.abs(tx - sx) / 2);
-      parts.push(
+      out.push(
         `<path class="dep-arrow" d="M ${sx} ${sy} C ${sx + dx} ${sy}, ${tx - dx} ${ty}, ` +
           `${tx} ${ty}" marker-end="url(#dep-arrowhead)"/>`
       );
     });
   });
+  return out;
+}
 
-  // --- Layer 3: items ---
-  positioned.forEach((p) => {
+/** Emits item bars/diamonds with hover tooltips. */
+function emitItems(positioned: PositionedItem[]): string[] {
+  return positioned.map((p) => {
     const tooltip = itemTooltip(p.item);
     if (p.isMilestone) {
       const cx = p.x + p.width / 2;
       const cy = p.centerY;
       const r = p.height / 2;
       const points = `${cx},${cy - r} ${cx + r},${cy} ${cx},${cy + r} ${cx - r},${cy}`;
-      parts.push(
+      return (
         `<g><title>${tooltip}</title>` +
-          `<polygon points="${points}" fill="${p.color}" stroke="${p.color}" ` +
-          `stroke-width="2" opacity="0.85"/>` +
-          `<text class="milestone-label" x="${cx + r + 8}" y="${cy}" dominant-baseline="middle" ` +
-          `font-size="11">${escapeXml(p.item.title)}</text>` +
-          `</g>`
-      );
-    } else {
-      const label =
-        p.width > 50
-          ? `<text x="${p.x + 6}" y="${p.centerY}" dominant-baseline="middle" ` +
-            `font-size="11" font-weight="bold" fill="#ffffff">` +
-            `${escapeXml(truncateToWidth(p.item.title, p.width - 12, 6.2))}</text>`
-          : '';
-      parts.push(
-        `<g><title>${tooltip}</title>` +
-          `<rect x="${p.x}" y="${p.y}" width="${p.width}" height="${p.height}" ` +
-          `rx="4" fill="${p.color}" opacity="0.9"/>` +
-          label +
-          `</g>`
+        `<polygon points="${points}" fill="${p.color}" stroke="${p.color}" ` +
+        `stroke-width="2" opacity="0.85"/>` +
+        `<text class="milestone-label" x="${cx + r + 8}" y="${cy}" dominant-baseline="middle" ` +
+        `font-size="11">${escapeXml(p.item.title)}</text>` +
+        `</g>`
       );
     }
-  });
-
-  // --- Layer 4: time axis (strip across the top, drawn over item tops) ---
-  parts.push(`<rect class="axis-strip" x="0" y="0" width="${svgWidth}" height="${margin.top}"/>`);
-  timeAxisTicks.forEach((tick) => {
-    const cls = tick.isMajor ? 'tick-major' : 'tick-minor';
-    parts.push(
-      `<line class="${cls}" x1="${tick.x}" y1="${margin.top - 10}" x2="${tick.x}" ` +
-        `y2="${margin.top}"/>`
+    const label =
+      p.width > 50
+        ? `<text x="${p.x + 6}" y="${p.centerY}" dominant-baseline="middle" ` +
+          `font-size="11" font-weight="bold" fill="#ffffff">` +
+          `${escapeXml(truncateToWidth(p.item.title, p.width - 12, 6.2))}</text>`
+        : '';
+    return (
+      `<g><title>${tooltip}</title>` +
+      `<rect x="${p.x}" y="${p.y}" width="${p.width}" height="${p.height}" ` +
+      `rx="4" fill="${p.color}" opacity="0.9"/>` +
+      label +
+      `</g>`
     );
-    parts.push(
-      `<text class="axis-label" x="${tick.x}" y="${margin.top - 16}" text-anchor="middle" ` +
+  });
+}
+
+/** Computes the x position of a date within the chart, or null if out of range. */
+function dateToX(model: ExportRenderModel, isoDate: string): number | null {
+  const { config, dateRange } = model;
+  if (!dateRange.minDate || !dateRange.maxDate || dateRange.timeRange <= 0) return null;
+  if (isoDate < dateRange.minDate || isoDate > dateRange.maxDate) return null;
+  const chartWidth = config.canvasWidth - config.margin.left - config.margin.right;
+  const ms = new Date(isoDate).getTime() - new Date(dateRange.minDate).getTime();
+  return config.margin.left + (ms / dateRange.timeRange) * chartWidth;
+}
+
+/** Emits a "Today" marker line if nowDate falls within the timeline range. */
+function emitTodayMarker(model: ExportRenderModel, nowDate: string | undefined): string[] {
+  if (!nowDate) return [];
+  const x = dateToX(model, nowDate);
+  if (x === null) return [];
+  const top = model.config.margin.top;
+  return [
+    `<line class="today-line" x1="${x}" y1="${top}" x2="${x}" y2="${model.svgHeight}">` +
+      `<title>Today: ${escapeXml(nowDate)}</title></line>`,
+    `<text class="today-label" x="${x + 4}" y="${top + 12}" font-size="10">Today</text>`,
+  ];
+}
+
+/** Emits the top time axis (strip, ticks, labels, baseline) across [0, width]. */
+function emitAxis(model: ExportRenderModel, width: number): string[] {
+  const top = model.config.margin.top;
+  const out: string[] = [`<rect class="axis-strip" x="0" y="0" width="${width}" height="${top}"/>`];
+  model.timeAxisTicks.forEach((tick) => {
+    const cls = tick.isMajor ? 'tick-major' : 'tick-minor';
+    out.push(`<line class="${cls}" x1="${tick.x}" y1="${top - 10}" x2="${tick.x}" y2="${top}"/>`);
+    out.push(
+      `<text class="axis-label" x="${tick.x}" y="${top - 16}" text-anchor="middle" ` +
         `font-size="12">${escapeXml(tick.label)}</text>`
     );
   });
-  parts.push(
-    `<line class="axis-line" x1="0" y1="${margin.top}" x2="${svgWidth}" y2="${margin.top}"/>`
-  );
+  out.push(`<line class="axis-line" x1="0" y1="${top}" x2="${width}" y2="${top}"/>`);
+  return out;
+}
 
-  // --- Layer 5: lane labels (strip down the left, drawn over item starts) ---
-  laneGroups.forEach((lane, index) => {
-    const top = laneTops[index] ?? margin.top;
+/** Emits lane label strips + text spanning [0, marginLeft]. */
+function emitLaneLabels(model: ExportRenderModel, laneTops: number[]): string[] {
+  const marginLeft = model.config.margin.left;
+  const out: string[] = [];
+  model.laneGroups.forEach((lane, index) => {
+    const top = laneTops[index] ?? model.config.margin.top;
     const centerY = top + lane.height / 2;
-    parts.push(
-      `<rect class="lane-strip" x="0" y="${top}" width="${margin.left}" height="${lane.height}"/>`
+    out.push(
+      `<rect class="lane-strip" x="0" y="${top}" width="${marginLeft}" height="${lane.height}"/>`
     );
-    const labelText = truncateToWidth(lane.laneName, margin.left - 20, 7.5);
-    parts.push(
+    const labelText = truncateToWidth(lane.laneName, marginLeft - 20, 7.5);
+    out.push(
       `<text class="lane-label" x="10" y="${centerY}" dominant-baseline="middle" font-size="14" ` +
         `font-weight="bold"><title>${escapeXml(lane.laneName)}</title>` +
         `${escapeXml(labelText)}</text>`
     );
   });
+  return out;
+}
 
-  parts.push('</svg>');
-  return parts.join('\n');
+/** Wraps body markup in an `<svg>` element. */
+function svgWrap(width: number, height: number, viewBox: string, body: string[]): string {
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" ` +
+    `viewBox="${viewBox}" font-family="-apple-system, system-ui, sans-serif">\n` +
+    body.join('\n') +
+    `\n</svg>`
+  );
+}
+
+/** Renders the empty-state SVG. */
+function emptySvg(width: number, height: number): string {
+  return svgWrap(width, height, `0 0 ${width} ${height}`, [
+    `<text class="empty-msg" x="${width / 2}" y="${height / 2}" text-anchor="middle" ` +
+      `font-size="16">No dated items to display</text>`,
+  ]);
+}
+
+/**
+ * Renders the full timeline model to a single self-contained SVG (chart + lane
+ * labels together). Used standalone; the artifact uses {@link renderChartSvg} +
+ * {@link renderGutterSvg} for a frozen label column.
+ *
+ * @param model - Render model from {@link buildRenderModel}
+ * @param options - Optional render options (e.g. today marker)
+ */
+export function renderSvg(model: ExportRenderModel, options: RenderSvgOptions = {}): string {
+  const { svgWidth, svgHeight, laneGroups, dateRange } = model;
+  if (laneGroups.length === 0 || !dateRange.minDate) return emptySvg(svgWidth, svgHeight);
+
+  const { laneTops, positioned, posMap } = computeLayout(model);
+  return svgWrap(svgWidth, svgHeight, `0 0 ${svgWidth} ${svgHeight}`, [
+    depArrowDefs(),
+    ...emitBackgrounds(model, laneTops, svgWidth),
+    ...emitTodayMarker(model, options.nowDate),
+    ...emitArrows(positioned, posMap),
+    ...emitItems(positioned),
+    ...emitAxis(model, svgWidth),
+    ...emitLaneLabels(model, laneTops),
+  ]);
+}
+
+/**
+ * Renders the scrollable chart (everything except the left lane-label column).
+ * The viewBox crops the left margin so x=0 begins at the chart area, letting a
+ * separate frozen gutter ({@link renderGutterSvg}) sit to its left.
+ */
+export function renderChartSvg(model: ExportRenderModel, options: RenderSvgOptions = {}): string {
+  const { svgWidth, svgHeight, laneGroups, dateRange, config } = model;
+  const chartWidth = Math.max(svgWidth - config.margin.left, 1);
+  if (laneGroups.length === 0 || !dateRange.minDate) return emptySvg(chartWidth, svgHeight);
+
+  const { laneTops, positioned, posMap } = computeLayout(model);
+  const viewBox = `${config.margin.left} 0 ${chartWidth} ${svgHeight}`;
+  return svgWrap(chartWidth, svgHeight, viewBox, [
+    depArrowDefs(),
+    ...emitBackgrounds(model, laneTops, svgWidth),
+    ...emitTodayMarker(model, options.nowDate),
+    ...emitArrows(positioned, posMap),
+    ...emitItems(positioned),
+    ...emitAxis(model, svgWidth),
+  ]);
+}
+
+/**
+ * Renders the frozen left gutter: alternating lane backgrounds, the top-left
+ * corner, and the lane labels. Stays fixed while the chart scrolls.
+ */
+export function renderGutterSvg(model: ExportRenderModel): string {
+  const { svgHeight, laneGroups, dateRange, config } = model;
+  const width = config.margin.left;
+  if (laneGroups.length === 0 || !dateRange.minDate) {
+    return svgWrap(width, svgHeight, `0 0 ${width} ${svgHeight}`, [
+      `<rect class="axis-strip" x="0" y="0" width="${width}" height="${svgHeight}"/>`,
+    ]);
+  }
+
+  const { laneTops } = computeLayout(model);
+  return svgWrap(width, svgHeight, `0 0 ${width} ${svgHeight}`, [
+    ...emitBackgrounds(model, laneTops, width),
+    ...emitLaneLabels(model, laneTops),
+    // Top-left corner over the lane backgrounds, aligned with the time axis.
+    `<rect class="axis-strip" x="0" y="0" width="${width}" height="${config.margin.top}"/>`,
+    `<text class="lane-corner" x="10" y="${config.margin.top - 16}" font-size="11">Lanes</text>`,
+  ]);
 }
 
 // ---------------------------------------------------------------------------
@@ -400,7 +500,8 @@ interface RenderedBranch {
   branchId: string;
   label: string;
   itemCount: number;
-  svg: string;
+  gutterSvg: string;
+  chartSvg: string;
 }
 
 /**
@@ -510,14 +611,19 @@ export function generateTimelineArtifact(
   const activeLabel = active.label || active.branchId;
   const title = options.title || `SwimLanes Timeline — ${activeLabel}`;
 
+  // "Today" marker date (the generation date), drawn if within a branch's range.
+  const nowDate = generatedAt.toISOString().split('T')[0];
+
   // Filter + render every branch (active shown initially, the rest hidden).
   const rendered: RenderedBranch[] = branches.map((b) => {
     const items = filterItems(b.items, filters);
+    const model = buildRenderModel(items, zoomLevel, laneGroupBy);
     return {
       branchId: b.branchId,
       label: b.label || b.branchId,
       itemCount: items.length,
-      svg: renderSvg(buildRenderModel(items, zoomLevel, laneGroupBy)),
+      gutterSvg: renderGutterSvg(model),
+      chartSvg: renderChartSvg(model, { nowDate }),
     };
   });
 
@@ -528,7 +634,10 @@ export function generateTimelineArtifact(
     .map((r) => {
       const hidden = r.branchId === activeBranchId ? '' : ' hidden';
       return `<section class="branch-view" data-branch-id="${escapeXml(r.branchId)}"${hidden}>
-${r.svg}
+  <div class="timeline-frame">
+    <div class="lane-gutter">${r.gutterSvg}</div>
+    <div class="timeline-scroll">${r.chartSvg}</div>
+  </div>
 </section>`;
     })
     .join('\n');
@@ -632,10 +741,19 @@ ${r.svg}
   }
   .scenario-btn.active .count { background: rgba(255, 255, 255, 0.25); }
   .branch-view[hidden] { display: none; }
-  .timeline-scroll { overflow: auto; padding: 16px 20px 40px; }
-  .timeline-scroll svg {
-    background: var(--svg-bg); border: 1px solid var(--border); border-radius: 8px;
+  /* Frozen lane-label gutter + scrollable chart */
+  .timeline-frame {
+    display: flex; align-items: flex-start; margin: 16px 20px 40px;
+    border: 1px solid var(--border); border-radius: 8px; overflow: hidden;
+    background: var(--svg-bg);
   }
+  .lane-gutter { flex: 0 0 auto; border-right: 1px solid var(--border); }
+  .timeline-scroll { flex: 1 1 auto; min-width: 0; overflow-x: auto; overflow-y: hidden; }
+  .lane-gutter svg, .timeline-scroll svg { display: block; }
+  .lane-corner { fill: var(--muted); font-weight: 600; }
+  .today-line { stroke: var(--accent); stroke-width: 1.5; stroke-dasharray: 4 3; opacity: 0.85; }
+  .today-label { fill: var(--accent); font-weight: 600; }
+  .timeline-scroll g:hover rect, .timeline-scroll g:hover polygon { opacity: 1; }
   /* Theme-able SVG chrome */
   .lane-bg-even { fill: var(--lane-even); }
   .lane-bg-odd { fill: var(--lane-odd); }
@@ -652,8 +770,8 @@ ${r.svg}
   @media print {
     body { background: #ffffff; }
     .no-print { display: none !important; }
-    .timeline-scroll { overflow: visible; padding: 0; }
-    .timeline-scroll svg { border: none; }
+    .timeline-frame { overflow: visible; max-width: none; }
+    .timeline-scroll { overflow: visible; }
     @page { size: landscape; margin: 1cm; }
   }
 </style>
@@ -682,7 +800,7 @@ ${r.svg}
   </button>
 </header>
 ${switcher}
-<main class="timeline-scroll">
+<main>
 ${branchViews}
 </main>
 <footer>Generated by SwimLanes · self-contained, offline timeline artifact</footer>

--- a/src/services/export.service.ts
+++ b/src/services/export.service.ts
@@ -167,6 +167,17 @@ function truncateToWidth(text: string, maxPx: number, pxPerChar: number): string
 // SVG rendering
 // ---------------------------------------------------------------------------
 
+/** Parses an item's `dependencies` field (a JSON array of item ids). */
+export function parseDependencies(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  try {
+    const value = JSON.parse(raw);
+    return Array.isArray(value) ? value.filter((x): x is string => typeof x === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
 /** Builds the multi-line hover tooltip text for an item (one item per `<title>`). */
 function itemTooltip(item: Item): string {
   const lines: string[] = [`${item.title} (${item.type})`];
@@ -179,12 +190,31 @@ function itemTooltip(item: Item): string {
   return escapeXml(lines.join('\n'));
 }
 
+/** Geometry of a positioned item, used for arrows and rendering. */
+interface PositionedItem {
+  item: Item;
+  isMilestone: boolean;
+  startX: number;
+  endX: number;
+  centerY: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  color: string;
+}
+
 /**
  * Renders the timeline render model to an SVG string.
  *
  * Visual encoding matches the app: tasks=blue, milestones=green diamonds,
  * releases=orange, meetings=purple. Lanes alternate background shades, with
- * fixed lane labels on the left and a time axis across the top.
+ * fixed lane labels on the left and a time axis across the top. Dependency
+ * arrows connect items whose `dependencies` reference another visible item.
+ *
+ * Theme-able chrome (backgrounds, axis, labels) is emitted with CSS classes so
+ * the surrounding document can recolor it for light/dark; item/brand colors
+ * stay inline. See {@link generateTimelineArtifact} for the class definitions.
  *
  * @param model - Render model from {@link buildRenderModel}
  * @returns Standalone `<svg>...</svg>` markup
@@ -202,26 +232,35 @@ export function renderSvg(model: ExportRenderModel): string {
   // Empty state
   if (laneGroups.length === 0 || !dateRange.minDate) {
     parts.push(
-      `<text x="${svgWidth / 2}" y="${svgHeight / 2}" text-anchor="middle" ` +
-        `font-size="16" fill="#6b7280">No dated items to display</text>`
+      `<text class="empty-msg" x="${svgWidth / 2}" y="${svgHeight / 2}" text-anchor="middle" ` +
+        `font-size="16">No dated items to display</text>`
     );
     parts.push('</svg>');
     return parts.join('\n');
   }
+
+  // Arrowhead marker for dependency connectors.
+  parts.push(
+    `<defs><marker id="dep-arrowhead" markerWidth="8" markerHeight="8" refX="7" refY="4" ` +
+      `orient="auto" markerUnits="userSpaceOnUse">` +
+      `<path d="M0,0 L8,4 L0,8 z" fill="#6b7280"/></marker></defs>`
+  );
 
   // --- Layer 1: lane backgrounds (alternating shades) ---
   let cumulativeY = margin.top;
   const laneTops: number[] = [];
   laneGroups.forEach((lane, index) => {
     laneTops.push(cumulativeY);
-    const fill = index % 2 === 0 ? '#e5e7eb' : '#ffffff';
+    const cls = index % 2 === 0 ? 'lane-bg-even' : 'lane-bg-odd';
     parts.push(
-      `<rect x="0" y="${cumulativeY}" width="${svgWidth}" height="${lane.height}" fill="${fill}"/>`
+      `<rect class="${cls}" x="0" y="${cumulativeY}" width="${svgWidth}" height="${lane.height}"/>`
     );
     cumulativeY += lane.height;
   });
 
-  // --- Layer 2: items ---
+  // --- Pass: compute positions for every item (for arrows + drawing) ---
+  const positioned: PositionedItem[] = [];
+  const posMap = new Map<string, PositionedItem>();
   laneGroups.forEach((lane, laneIndex) => {
     const laneTop = laneTops[laneIndex] ?? margin.top;
     const rowMap = assignItemRows(lane.items);
@@ -233,73 +272,107 @@ export function renderSvg(model: ExportRenderModel): string {
       const rowIndex = rowMap.get(item.id) ?? 0;
       const itemY =
         laneTop + config.itemPadding + rowIndex * (config.itemHeight + config.itemPadding);
-      const color = DEFAULT_ITEM_COLORS[item.type];
-      const tooltip = itemTooltip(item);
+      const isMilestone = item.type === 'milestone';
+      const centerY = itemY + pos.height / 2;
+      const r = pos.height / 2;
+      const cx = pos.x + pos.width / 2;
 
-      if (item.type === 'milestone') {
-        // Diamond centered on the start date
-        const cx = pos.x + pos.width / 2;
-        const cy = itemY + pos.height / 2;
-        const r = pos.height / 2;
-        const points = `${cx},${cy - r} ${cx + r},${cy} ${cx},${cy + r} ${cx - r},${cy}`;
-        parts.push(
-          `<g><title>${tooltip}</title>` +
-            `<polygon points="${points}" fill="${color}" stroke="${color}" ` +
-            `stroke-width="2" opacity="0.85"/>` +
-            `<text x="${cx + r + 8}" y="${cy}" dominant-baseline="middle" ` +
-            `font-size="11" fill="#374151">${escapeXml(item.title)}</text>` +
-            `</g>`
-        );
-      } else {
-        // Bar for task / release / meeting
-        const label =
-          pos.width > 50
-            ? `<text x="${pos.x + 6}" y="${itemY + pos.height / 2}" dominant-baseline="middle" ` +
-              `font-size="11" font-weight="bold" fill="#ffffff">` +
-              `${escapeXml(truncateToWidth(item.title, pos.width - 12, 6.2))}</text>`
-            : '';
-        parts.push(
-          `<g><title>${tooltip}</title>` +
-            `<rect x="${pos.x}" y="${itemY}" width="${pos.width}" height="${pos.height}" ` +
-            `rx="4" fill="${color}" opacity="0.9"/>` +
-            label +
-            `</g>`
-        );
-      }
+      const entry: PositionedItem = {
+        item,
+        isMilestone,
+        startX: isMilestone ? cx - r : pos.x,
+        endX: isMilestone ? cx + r : pos.x + pos.width,
+        centerY,
+        x: pos.x,
+        y: itemY,
+        width: pos.width,
+        height: pos.height,
+        color: DEFAULT_ITEM_COLORS[item.type],
+      };
+      positioned.push(entry);
+      // Last writer wins on duplicate ids; fine for arrow anchoring.
+      posMap.set(item.id, entry);
     });
   });
 
-  // --- Layer 3: time axis (white strip across the top, drawn over item tops) ---
-  parts.push(`<rect x="0" y="0" width="${svgWidth}" height="${margin.top}" fill="#ffffff"/>`);
+  // --- Layer 2: dependency arrows (under items, so bars sit on top) ---
+  positioned.forEach((target) => {
+    parseDependencies(target.item.dependencies).forEach((depId) => {
+      const source = posMap.get(depId);
+      if (!source) return;
+      const sx = source.endX;
+      const sy = source.centerY;
+      const tx = target.startX;
+      const ty = target.centerY;
+      const dx = Math.max(16, Math.abs(tx - sx) / 2);
+      parts.push(
+        `<path class="dep-arrow" d="M ${sx} ${sy} C ${sx + dx} ${sy}, ${tx - dx} ${ty}, ` +
+          `${tx} ${ty}" marker-end="url(#dep-arrowhead)"/>`
+      );
+    });
+  });
+
+  // --- Layer 3: items ---
+  positioned.forEach((p) => {
+    const tooltip = itemTooltip(p.item);
+    if (p.isMilestone) {
+      const cx = p.x + p.width / 2;
+      const cy = p.centerY;
+      const r = p.height / 2;
+      const points = `${cx},${cy - r} ${cx + r},${cy} ${cx},${cy + r} ${cx - r},${cy}`;
+      parts.push(
+        `<g><title>${tooltip}</title>` +
+          `<polygon points="${points}" fill="${p.color}" stroke="${p.color}" ` +
+          `stroke-width="2" opacity="0.85"/>` +
+          `<text class="milestone-label" x="${cx + r + 8}" y="${cy}" dominant-baseline="middle" ` +
+          `font-size="11">${escapeXml(p.item.title)}</text>` +
+          `</g>`
+      );
+    } else {
+      const label =
+        p.width > 50
+          ? `<text x="${p.x + 6}" y="${p.centerY}" dominant-baseline="middle" ` +
+            `font-size="11" font-weight="bold" fill="#ffffff">` +
+            `${escapeXml(truncateToWidth(p.item.title, p.width - 12, 6.2))}</text>`
+          : '';
+      parts.push(
+        `<g><title>${tooltip}</title>` +
+          `<rect x="${p.x}" y="${p.y}" width="${p.width}" height="${p.height}" ` +
+          `rx="4" fill="${p.color}" opacity="0.9"/>` +
+          label +
+          `</g>`
+      );
+    }
+  });
+
+  // --- Layer 4: time axis (strip across the top, drawn over item tops) ---
+  parts.push(`<rect class="axis-strip" x="0" y="0" width="${svgWidth}" height="${margin.top}"/>`);
   timeAxisTicks.forEach((tick) => {
-    const stroke = tick.isMajor ? '#333333' : '#999999';
-    const strokeWidth = tick.isMajor ? 2 : 1;
+    const cls = tick.isMajor ? 'tick-major' : 'tick-minor';
     parts.push(
-      `<line x1="${tick.x}" y1="${margin.top - 10}" x2="${tick.x}" y2="${margin.top}" ` +
-        `stroke="${stroke}" stroke-width="${strokeWidth}"/>`
+      `<line class="${cls}" x1="${tick.x}" y1="${margin.top - 10}" x2="${tick.x}" ` +
+        `y2="${margin.top}"/>`
     );
     parts.push(
-      `<text x="${tick.x}" y="${margin.top - 16}" text-anchor="middle" font-size="12" ` +
-        `fill="#333333">${escapeXml(tick.label)}</text>`
+      `<text class="axis-label" x="${tick.x}" y="${margin.top - 16}" text-anchor="middle" ` +
+        `font-size="12">${escapeXml(tick.label)}</text>`
     );
   });
   parts.push(
-    `<line x1="0" y1="${margin.top}" x2="${svgWidth}" y2="${margin.top}" ` +
-      `stroke="#333333" stroke-width="2"/>`
+    `<line class="axis-line" x1="0" y1="${margin.top}" x2="${svgWidth}" y2="${margin.top}"/>`
   );
 
-  // --- Layer 4: lane labels (white strip down the left, drawn over item starts) ---
+  // --- Layer 5: lane labels (strip down the left, drawn over item starts) ---
   laneGroups.forEach((lane, index) => {
     const top = laneTops[index] ?? margin.top;
     const centerY = top + lane.height / 2;
     parts.push(
-      `<rect x="0" y="${top}" width="${margin.left}" height="${lane.height}" ` +
-        `fill="#ffffff" opacity="0.97"/>`
+      `<rect class="lane-strip" x="0" y="${top}" width="${margin.left}" height="${lane.height}"/>`
     );
     const labelText = truncateToWidth(lane.laneName, margin.left - 20, 7.5);
     parts.push(
-      `<text x="10" y="${centerY}" dominant-baseline="middle" font-size="14" ` +
-        `font-weight="bold" fill="#4b5563"><title>${escapeXml(lane.laneName)}</title>` +
+      `<text class="lane-label" x="10" y="${centerY}" dominant-baseline="middle" font-size="14" ` +
+        `font-weight="bold"><title>${escapeXml(lane.laneName)}</title>` +
         `${escapeXml(labelText)}</text>`
     );
   });
@@ -381,6 +454,28 @@ function renderSwitcherScript(): string {
       activate(b.getAttribute('data-branch-id'), b.getAttribute('data-label'), b.getAttribute('data-item-count'));
     });
   });
+})();
+</script>`;
+}
+
+/**
+ * Runtime script for the light/dark theme toggle. Initializes from the OS
+ * preference and lets the reader flip it; the choice is not persisted (the
+ * artifact is a stateless snapshot).
+ */
+function renderThemeScript(): string {
+  return `<script>
+(function () {
+  var root = document.documentElement;
+  var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  root.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
+  var btn = document.getElementById('theme-toggle');
+  if (btn) {
+    btn.addEventListener('click', function () {
+      var next = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      root.setAttribute('data-theme', next);
+    });
+  }
 })();
 </script>`;
 }
@@ -470,77 +565,131 @@ ${r.svg}
 <meta name="generator" content="SwimLanes"/>
 <title>${escapeXml(title)}</title>
 <style>
-  :root { color-scheme: light; }
+  :root {
+    color-scheme: light;
+    --bg: #f9fafb; --panel: #ffffff; --border: #e5e7eb;
+    --text: #1f2937; --muted: #6b7280; --label: #4b5563;
+    --btn-bg: #f9fafb; --btn-border: #d1d5db; --btn-text: #374151; --btn-hover: #f3f4f6;
+    --accent: #2563eb; --accent-text: #ffffff;
+    --svg-bg: #ffffff;
+    --lane-even: #e5e7eb; --lane-odd: #ffffff; --strip: #ffffff;
+    --axis: #333333; --tick-minor: #999999; --milestone-label: #374151;
+    --count-bg: rgba(0,0,0,0.08);
+  }
+  :root[data-theme="dark"] {
+    color-scheme: dark;
+    --bg: #0b1220; --panel: #111827; --border: #1f2937;
+    --text: #e5e7eb; --muted: #9ca3af; --label: #cbd5e1;
+    --btn-bg: #1f2937; --btn-border: #374151; --btn-text: #e5e7eb; --btn-hover: #374151;
+    --accent: #3b82f6; --accent-text: #ffffff;
+    --svg-bg: #0f172a;
+    --lane-even: #1e293b; --lane-odd: #0f172a; --strip: #111827;
+    --axis: #cbd5e1; --tick-minor: #64748b; --milestone-label: #e5e7eb;
+    --count-bg: rgba(255,255,255,0.18);
+  }
   * { box-sizing: border-box; }
   body {
     margin: 0;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, system-ui, sans-serif;
-    color: #1f2937;
-    background: #f9fafb;
+    color: var(--text); background: var(--bg);
+    -webkit-print-color-adjust: exact; print-color-adjust: exact;
   }
   header {
-    padding: 16px 20px;
-    background: #ffffff;
-    border-bottom: 1px solid #e5e7eb;
+    display: flex; align-items: flex-start; justify-content: space-between; gap: 16px;
+    padding: 16px 20px; background: var(--panel); border-bottom: 1px solid var(--border);
   }
   header h1 { margin: 0 0 4px; font-size: 18px; }
-  header .meta { font-size: 12px; color: #6b7280; }
+  header .meta { font-size: 12px; color: var(--muted); }
   header .meta span { margin-right: 16px; white-space: nowrap; }
-  .legend { margin-top: 8px; font-size: 12px; color: #4b5563; }
+  .legend { margin-top: 8px; font-size: 12px; color: var(--label); }
   .legend .swatch {
     display: inline-block; width: 10px; height: 10px; border-radius: 2px;
     margin: 0 4px 0 12px; vertical-align: middle;
   }
   .legend .swatch:first-child { margin-left: 0; }
+  .theme-toggle {
+    flex: none; font: inherit; font-size: 13px; padding: 6px 12px;
+    border: 1px solid var(--btn-border); border-radius: 6px;
+    background: var(--btn-bg); color: var(--btn-text); cursor: pointer;
+  }
+  .theme-toggle:hover { background: var(--btn-hover); }
   .scenario-switcher {
     display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
-    padding: 12px 20px; background: #ffffff; border-bottom: 1px solid #e5e7eb;
+    padding: 12px 20px; background: var(--panel); border-bottom: 1px solid var(--border);
   }
   .scenario-switcher .switcher-label {
-    font-size: 12px; font-weight: 600; color: #6b7280; margin-right: 4px;
+    font-size: 12px; font-weight: 600; color: var(--muted); margin-right: 4px;
   }
   .scenario-btn {
-    font: inherit; font-size: 13px; padding: 6px 12px; border: 1px solid #d1d5db;
-    border-radius: 6px; background: #f9fafb; color: #374151; cursor: pointer;
+    font: inherit; font-size: 13px; padding: 6px 12px; border: 1px solid var(--btn-border);
+    border-radius: 6px; background: var(--btn-bg); color: var(--btn-text); cursor: pointer;
   }
-  .scenario-btn:hover { background: #f3f4f6; }
-  .scenario-btn.active { background: #2563eb; border-color: #2563eb; color: #ffffff; }
+  .scenario-btn:hover { background: var(--btn-hover); }
+  .scenario-btn.active { background: var(--accent); border-color: var(--accent); color: var(--accent-text); }
   .scenario-btn .count {
     display: inline-block; min-width: 18px; padding: 0 4px; margin-left: 4px;
-    font-size: 11px; text-align: center; border-radius: 9px;
-    background: rgba(0, 0, 0, 0.08);
+    font-size: 11px; text-align: center; border-radius: 9px; background: var(--count-bg);
   }
   .scenario-btn.active .count { background: rgba(255, 255, 255, 0.25); }
   .branch-view[hidden] { display: none; }
   .timeline-scroll { overflow: auto; padding: 16px 20px 40px; }
-  .timeline-scroll svg { background: #ffffff; border: 1px solid #e5e7eb; border-radius: 8px; }
+  .timeline-scroll svg {
+    background: var(--svg-bg); border: 1px solid var(--border); border-radius: 8px;
+  }
+  /* Theme-able SVG chrome */
+  .lane-bg-even { fill: var(--lane-even); }
+  .lane-bg-odd { fill: var(--lane-odd); }
+  .axis-strip { fill: var(--strip); }
+  .lane-strip { fill: var(--strip); fill-opacity: 0.97; }
+  .axis-line, .tick-major { stroke: var(--axis); stroke-width: 2; }
+  .tick-minor { stroke: var(--tick-minor); stroke-width: 1; }
+  .axis-label { fill: var(--axis); }
+  .lane-label { fill: var(--label); }
+  .milestone-label { fill: var(--milestone-label); }
+  .empty-msg { fill: var(--muted); }
+  .dep-arrow { stroke: #6b7280; stroke-width: 1.5; fill: none; opacity: 0.75; }
+  footer { padding: 12px 20px 28px; font-size: 11px; color: var(--muted); }
+  @media print {
+    body { background: #ffffff; }
+    .no-print { display: none !important; }
+    .timeline-scroll { overflow: visible; padding: 0; }
+    .timeline-scroll svg { border: none; }
+    @page { size: landscape; margin: 1cm; }
+  }
 </style>
 </head>
 <body>
 <header>
-  <h1>${escapeXml(title)}</h1>
-  <div class="meta">
-    <span>Branch: <strong id="meta-branch">${escapeXml(activeLabel)}</strong></span>
-    <span>Items: <strong id="meta-items">${itemCount}</strong></span>
-    <span>Zoom: ${escapeXml(zoomLevel)}</span>
-    <span>Grouped by: ${escapeXml(laneGroupBy)}</span>
-    <span>Filters: ${escapeXml(filterSummary)}</span>
-    <span>Generated: ${escapeXml(generatedDisplay)}</span>
+  <div class="header-main">
+    <h1>${escapeXml(title)}</h1>
+    <div class="meta">
+      <span>Branch: <strong id="meta-branch">${escapeXml(activeLabel)}</strong></span>
+      <span>Items: <strong id="meta-items">${itemCount}</strong></span>
+      <span>Zoom: ${escapeXml(zoomLevel)}</span>
+      <span>Grouped by: ${escapeXml(laneGroupBy)}</span>
+      <span>Filters: ${escapeXml(filterSummary)}</span>
+      <span>Generated: ${escapeXml(generatedDisplay)}</span>
+    </div>
+    <div class="legend">
+      <span class="swatch" style="background:${DEFAULT_ITEM_COLORS.task}"></span>Task
+      <span class="swatch" style="background:${DEFAULT_ITEM_COLORS.milestone}"></span>Milestone
+      <span class="swatch" style="background:${DEFAULT_ITEM_COLORS.release}"></span>Release
+      <span class="swatch" style="background:${DEFAULT_ITEM_COLORS.meeting}"></span>Meeting
+    </div>
   </div>
-  <div class="legend">
-    <span class="swatch" style="background:${DEFAULT_ITEM_COLORS.task}"></span>Task
-    <span class="swatch" style="background:${DEFAULT_ITEM_COLORS.milestone}"></span>Milestone
-    <span class="swatch" style="background:${DEFAULT_ITEM_COLORS.release}"></span>Release
-    <span class="swatch" style="background:${DEFAULT_ITEM_COLORS.meeting}"></span>Meeting
-  </div>
+  <button type="button" id="theme-toggle" class="theme-toggle no-print" aria-label="Toggle theme">
+    Theme
+  </button>
 </header>
 ${switcher}
 <main class="timeline-scroll">
 ${branchViews}
 </main>
+<footer>Generated by SwimLanes · self-contained, offline timeline artifact</footer>
 <script type="application/json" id="swimlanes-data">
 ${payloadJson}
 </script>
+${renderThemeScript()}
 ${switcherScript}
 </body>
 </html>`;

--- a/src/services/export.service.ts
+++ b/src/services/export.service.ts
@@ -208,6 +208,9 @@ interface PositionedItem {
 export interface RenderSvgOptions {
   /** If set (ISO YYYY-MM-DD) and within range, draws a "Today" marker line. */
   nowDate?: string;
+
+  /** Zoom level, used to choose period-shading bands (weekends vs month/quarter/year). */
+  zoom?: ZoomLevel;
 }
 
 /** Computes lane tops and positioned items for a model. */
@@ -345,6 +348,99 @@ function dateToX(model: ExportRenderModel, isoDate: string): number | null {
   return config.margin.left + (ms / dateRange.timeRange) * chartWidth;
 }
 
+/** Maps a timestamp to an x position, clamped to the chart bounds. */
+function xForMs(model: ExportRenderModel, ms: number): number {
+  const { config, dateRange } = model;
+  const chartW = config.canvasWidth - config.margin.left - config.margin.right;
+  const start = new Date(dateRange.minDate as string).getTime();
+  const x =
+    config.margin.left + (dateRange.timeRange ? (ms - start) / dateRange.timeRange : 0) * chartW;
+  return Math.max(config.margin.left, Math.min(config.margin.left + chartW, x));
+}
+
+/** The calendar period to alternate-shade for a given zoom (null = weekends). */
+type BandKind = 'month' | 'quarter' | 'year';
+function bandKindForZoom(zoom: ZoomLevel): BandKind | null {
+  switch (zoom) {
+    case 'day':
+      return null; // weekend shading instead
+    case 'week':
+    case 'month':
+      return 'month';
+    case 'quarter':
+      return 'quarter';
+    case 'year':
+      return 'year';
+  }
+}
+
+/** Computes period start timestamps (UTC) spanning the range, plus a trailing sentinel. */
+function periodStarts(minMs: number, maxMs: number, kind: BandKind): number[] {
+  const d = new Date(minMs);
+  const y = d.getUTCFullYear();
+  let m = d.getUTCMonth();
+  if (kind === 'quarter') m = Math.floor(m / 3) * 3;
+  if (kind === 'year') m = 0;
+  const step = (cur: number): number => {
+    const c = new Date(cur);
+    const cy = c.getUTCFullYear();
+    const cm = c.getUTCMonth();
+    if (kind === 'month') return Date.UTC(cy, cm + 1, 1);
+    if (kind === 'quarter') return Date.UTC(cy, cm + 3, 1);
+    return Date.UTC(cy + 1, 0, 1);
+  };
+  const starts: number[] = [];
+  let cur = Date.UTC(y, m, 1);
+  while (cur <= maxMs) {
+    starts.push(cur);
+    cur = step(cur);
+  }
+  starts.push(cur); // trailing sentinel so the last band has an end
+  return starts;
+}
+
+/**
+ * Emits faint vertical period-shading bands behind the chart to aid reading
+ * dates after scrolling. Weekends at day zoom; alternating months/quarters/years
+ * otherwise. Drawn over lane backgrounds (semi-transparent) and under items.
+ */
+function emitPeriodBands(model: ExportRenderModel, zoom: ZoomLevel | undefined): string[] {
+  if (!zoom) return [];
+  const { dateRange, config, svgHeight } = model;
+  if (!dateRange.minDate || !dateRange.maxDate || dateRange.timeRange <= 0) return [];
+
+  const top = config.margin.top;
+  const h = svgHeight - top;
+  const minMs = new Date(dateRange.minDate).getTime();
+  const maxMs = new Date(dateRange.maxDate).getTime();
+  const out: string[] = [];
+  const band = (x0: number, x1: number, cls: string): void => {
+    const w = x1 - x0;
+    if (w > 0.5) out.push(`<rect class="${cls}" x="${x0}" y="${top}" width="${w}" height="${h}"/>`);
+  };
+
+  const kind = bandKindForZoom(zoom);
+  if (kind === null) {
+    // Weekend shading (Sat/Sun) at day zoom.
+    const dayMs = 86400000;
+    const d0 = new Date(minMs);
+    let cur = Date.UTC(d0.getUTCFullYear(), d0.getUTCMonth(), d0.getUTCDate());
+    while (cur <= maxMs) {
+      const dow = new Date(cur).getUTCDay();
+      if (dow === 0 || dow === 6)
+        band(xForMs(model, cur), xForMs(model, cur + dayMs), 'weekend-band');
+      cur += dayMs;
+    }
+    return out;
+  }
+
+  const starts = periodStarts(minMs, maxMs, kind);
+  for (let i = 0; i + 1 < starts.length; i++) {
+    if (i % 2 === 1) band(xForMs(model, starts[i]!), xForMs(model, starts[i + 1]!), 'period-band');
+  }
+  return out;
+}
+
 /** Emits a "Today" marker line if nowDate falls within the timeline range. */
 function emitTodayMarker(model: ExportRenderModel, nowDate: string | undefined): string[] {
   if (!nowDate) return [];
@@ -384,11 +480,16 @@ function emitLaneLabels(model: ExportRenderModel, laneTops: number[]): string[] 
     out.push(
       `<rect class="lane-strip" x="0" y="${top}" width="${marginLeft}" height="${lane.height}"/>`
     );
-    const labelText = truncateToWidth(lane.laneName, marginLeft - 20, 7.5);
+    // Leave room on the right for the item-count badge.
+    const labelText = truncateToWidth(lane.laneName, marginLeft - 44, 7.5);
     out.push(
       `<text class="lane-label" x="10" y="${centerY}" dominant-baseline="middle" font-size="14" ` +
         `font-weight="bold"><title>${escapeXml(lane.laneName)}</title>` +
         `${escapeXml(labelText)}</text>`
+    );
+    out.push(
+      `<text class="lane-count" x="${marginLeft - 10}" y="${centerY}" text-anchor="end" ` +
+        `dominant-baseline="middle" font-size="11">${lane.items.length}</text>`
     );
   });
   return out;
@@ -429,6 +530,7 @@ export function renderSvg(model: ExportRenderModel, options: RenderSvgOptions = 
   return svgWrap(svgWidth, svgHeight, `0 0 ${svgWidth} ${svgHeight}`, [
     depArrowDefs(),
     ...emitBackgrounds(model, laneTops, svgWidth),
+    ...emitPeriodBands(model, options.zoom),
     ...emitTodayMarker(model, options.nowDate),
     ...emitArrows(positioned, posMap),
     ...emitItems(positioned),
@@ -510,6 +612,7 @@ export function renderBodySvg(model: ExportRenderModel, options: RenderSvgOption
   return svgWrap(w, h, viewBox, [
     depArrowDefs(),
     ...emitBackgrounds(model, laneTops, model.svgWidth),
+    ...emitPeriodBands(model, options.zoom),
     ...emitTodayMarker(model, options.nowDate),
     ...emitArrows(positioned, posMap),
     ...emitItems(positioned),
@@ -732,7 +835,11 @@ export function generateTimelineArtifact(
       labelsSvg: renderLabelsSvg(baseModel),
       charts: zoomLevels.map((zoom) => {
         const model = buildRenderModel(items, zoom, laneGroupBy);
-        return { zoom, axisSvg: renderAxisSvg(model), bodySvg: renderBodySvg(model, { nowDate }) };
+        return {
+          zoom,
+          axisSvg: renderAxisSvg(model),
+          bodySvg: renderBodySvg(model, { nowDate, zoom }),
+        };
       }),
     };
   });
@@ -809,6 +916,7 @@ export function generateTimelineArtifact(
     --lane-even: #e5e7eb; --lane-odd: #ffffff; --strip: #ffffff;
     --axis: #333333; --tick-minor: #999999; --milestone-label: #374151;
     --count-bg: rgba(0,0,0,0.08);
+    --band: rgba(15,23,42,0.045); --weekend: rgba(15,23,42,0.07);
   }
   :root[data-theme="dark"] {
     color-scheme: dark;
@@ -820,6 +928,7 @@ export function generateTimelineArtifact(
     --lane-even: #1e293b; --lane-odd: #0f172a; --strip: #111827;
     --axis: #cbd5e1; --tick-minor: #64748b; --milestone-label: #e5e7eb;
     --count-bg: rgba(255,255,255,0.18);
+    --band: rgba(148,163,184,0.10); --weekend: rgba(148,163,184,0.16);
   }
   * { box-sizing: border-box; }
   body {
@@ -895,6 +1004,9 @@ export function generateTimelineArtifact(
   .timeline-grid svg { display: block; }
   .zoom-pane[hidden] { display: none; }
   .lane-corner { fill: var(--muted); font-weight: 600; }
+  .lane-count { fill: var(--muted); }
+  .period-band { fill: var(--band); }
+  .weekend-band { fill: var(--weekend); }
   .today-line { stroke: var(--accent); stroke-width: 1.5; stroke-dasharray: 4 3; opacity: 0.85; }
   .today-label { fill: var(--accent); font-weight: 600; }
   .body-col g:hover rect, .body-col g:hover polygon { opacity: 1; }

--- a/src/services/export.service.ts
+++ b/src/services/export.service.ts
@@ -322,14 +322,78 @@ function describeFilters(filters: ExportFilters): string {
   return parts.length > 0 ? parts.join(', ') : 'none';
 }
 
+/** One branch rendered to SVG, with the metadata the switcher/header need. */
+interface RenderedBranch {
+  branchId: string;
+  label: string;
+  itemCount: number;
+  svg: string;
+}
+
+/**
+ * Builds the scenario switcher markup (one button per branch). Returns an empty
+ * string when there is only a single branch (no switcher needed).
+ */
+function renderSwitcher(rendered: RenderedBranch[], activeBranchId: string): string {
+  if (rendered.length <= 1) return '';
+
+  const buttons = rendered
+    .map((r) => {
+      const on = r.branchId === activeBranchId;
+      return (
+        `<button type="button" class="scenario-btn${on ? ' active' : ''}" ` +
+        `data-branch-id="${escapeXml(r.branchId)}" data-label="${escapeXml(r.label)}" ` +
+        `data-item-count="${r.itemCount}" aria-pressed="${on ? 'true' : 'false'}">` +
+        `${escapeXml(r.label)} <span class="count">${r.itemCount}</span></button>`
+      );
+    })
+    .join('\n    ');
+
+  return `<div class="scenario-switcher" role="group" aria-label="Scenarios">
+    <span class="switcher-label">Scenario:</span>
+    ${buttons}
+  </div>`;
+}
+
+/**
+ * Runtime script (vanilla JS) that toggles which branch view is visible and
+ * updates the header counts. Only emitted when there is more than one branch.
+ */
+function renderSwitcherScript(): string {
+  return `<script>
+(function () {
+  var views = document.querySelectorAll('.branch-view');
+  var btns = document.querySelectorAll('.scenario-btn');
+  var metaBranch = document.getElementById('meta-branch');
+  var metaItems = document.getElementById('meta-items');
+  function activate(id, label, count) {
+    views.forEach(function (v) { v.hidden = v.getAttribute('data-branch-id') !== id; });
+    btns.forEach(function (b) {
+      var on = b.getAttribute('data-branch-id') === id;
+      b.classList.toggle('active', on);
+      b.setAttribute('aria-pressed', on ? 'true' : 'false');
+    });
+    if (metaBranch && label != null) metaBranch.textContent = label;
+    if (metaItems && count != null) metaItems.textContent = count;
+  }
+  btns.forEach(function (b) {
+    b.addEventListener('click', function () {
+      activate(b.getAttribute('data-branch-id'), b.getAttribute('data-label'), b.getAttribute('data-item-count'));
+    });
+  });
+})();
+</script>`;
+}
+
 /**
  * Generates the complete self-contained HTML artifact for one or more branches.
  *
- * v1 renders the active branch's timeline as inline SVG and embeds every
- * provided branch's data as JSON (for v2 to consume). No external requests,
- * no runtime dependencies.
+ * When multiple branches are supplied, all are rendered into the single file and
+ * an embedded vanilla-JS switcher lets the reader toggle between scenarios
+ * offline. The active branch is shown initially. Every branch's data is also
+ * embedded as JSON. No external requests, no runtime dependencies.
  *
- * @param branches - Branch data to bake in (v1 callers pass one)
+ * @param branches - Branch data to bake in (one for a single-scenario export)
  * @param options - Export options (active branch, zoom, grouping, filters, title)
  * @returns A full HTML document string
  * @throws If the active branch is not present in `branches`
@@ -351,12 +415,33 @@ export function generateTimelineArtifact(
   const activeLabel = active.label || active.branchId;
   const title = options.title || `SwimLanes Timeline — ${activeLabel}`;
 
-  // Filter then render the active branch.
-  const filteredActiveItems = filterItems(active.items, filters);
-  const model = buildRenderModel(filteredActiveItems, zoomLevel, laneGroupBy);
-  const svg = renderSvg(model);
+  // Filter + render every branch (active shown initially, the rest hidden).
+  const rendered: RenderedBranch[] = branches.map((b) => {
+    const items = filterItems(b.items, filters);
+    return {
+      branchId: b.branchId,
+      label: b.label || b.branchId,
+      itemCount: items.length,
+      svg: renderSvg(buildRenderModel(items, zoomLevel, laneGroupBy)),
+    };
+  });
 
-  // Build the N-branch payload (each branch's items pre-filtered for v2 reuse).
+  const activeBranchId = options.activeBranchId;
+  const activeRendered = rendered.find((r) => r.branchId === activeBranchId)!;
+
+  const branchViews = rendered
+    .map((r) => {
+      const hidden = r.branchId === activeBranchId ? '' : ' hidden';
+      return `<section class="branch-view" data-branch-id="${escapeXml(r.branchId)}"${hidden}>
+${r.svg}
+</section>`;
+    })
+    .join('\n');
+
+  const switcher = renderSwitcher(rendered, activeBranchId);
+  const switcherScript = rendered.length > 1 ? renderSwitcherScript() : '';
+
+  // Build the N-branch payload (each branch's items pre-filtered).
   const payload: ExportPayload = {
     formatVersion: EXPORT_FORMAT_VERSION,
     title,
@@ -364,7 +449,7 @@ export function generateTimelineArtifact(
     zoomLevel,
     laneGroupBy,
     filters,
-    activeBranchId: options.activeBranchId,
+    activeBranchId,
     branches: branches.map((b) => ({
       branchId: b.branchId,
       label: b.label ?? null,
@@ -373,7 +458,7 @@ export function generateTimelineArtifact(
   };
   const payloadJson = escapeForScript(JSON.stringify(payload));
 
-  const itemCount = filteredActiveItems.length;
+  const itemCount = activeRendered.itemCount;
   const generatedDisplay = generatedAt.toLocaleString();
   const filterSummary = describeFilters(filters);
 
@@ -407,6 +492,26 @@ export function generateTimelineArtifact(
     margin: 0 4px 0 12px; vertical-align: middle;
   }
   .legend .swatch:first-child { margin-left: 0; }
+  .scenario-switcher {
+    display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
+    padding: 12px 20px; background: #ffffff; border-bottom: 1px solid #e5e7eb;
+  }
+  .scenario-switcher .switcher-label {
+    font-size: 12px; font-weight: 600; color: #6b7280; margin-right: 4px;
+  }
+  .scenario-btn {
+    font: inherit; font-size: 13px; padding: 6px 12px; border: 1px solid #d1d5db;
+    border-radius: 6px; background: #f9fafb; color: #374151; cursor: pointer;
+  }
+  .scenario-btn:hover { background: #f3f4f6; }
+  .scenario-btn.active { background: #2563eb; border-color: #2563eb; color: #ffffff; }
+  .scenario-btn .count {
+    display: inline-block; min-width: 18px; padding: 0 4px; margin-left: 4px;
+    font-size: 11px; text-align: center; border-radius: 9px;
+    background: rgba(0, 0, 0, 0.08);
+  }
+  .scenario-btn.active .count { background: rgba(255, 255, 255, 0.25); }
+  .branch-view[hidden] { display: none; }
   .timeline-scroll { overflow: auto; padding: 16px 20px 40px; }
   .timeline-scroll svg { background: #ffffff; border: 1px solid #e5e7eb; border-radius: 8px; }
 </style>
@@ -415,8 +520,8 @@ export function generateTimelineArtifact(
 <header>
   <h1>${escapeXml(title)}</h1>
   <div class="meta">
-    <span>Branch: <strong>${escapeXml(activeLabel)}</strong></span>
-    <span>Items: <strong>${itemCount}</strong></span>
+    <span>Branch: <strong id="meta-branch">${escapeXml(activeLabel)}</strong></span>
+    <span>Items: <strong id="meta-items">${itemCount}</strong></span>
     <span>Zoom: ${escapeXml(zoomLevel)}</span>
     <span>Grouped by: ${escapeXml(laneGroupBy)}</span>
     <span>Filters: ${escapeXml(filterSummary)}</span>
@@ -429,12 +534,14 @@ export function generateTimelineArtifact(
     <span class="swatch" style="background:${DEFAULT_ITEM_COLORS.meeting}"></span>Meeting
   </div>
 </header>
+${switcher}
 <main class="timeline-scroll">
-${svg}
+${branchViews}
 </main>
 <script type="application/json" id="swimlanes-data">
 ${payloadJson}
 </script>
+${switcherScript}
 </body>
 </html>`;
 }

--- a/src/types/export.types.ts
+++ b/src/types/export.types.ts
@@ -1,0 +1,144 @@
+/**
+ * HTML timeline artifact export type definitions for SwimLanes
+ *
+ * These types support exporting a branch (and, in future, multiple branches)
+ * to a standalone, self-contained HTML file with an inlined dataset and a
+ * hand-rolled SVG renderer. See `ref/html-artifact-export.md`.
+ */
+
+import type { Item } from './database.types';
+import type {
+  ZoomLevel,
+  LaneGroupBy,
+  DateRange,
+  LaneGroup,
+  TimeAxisTick,
+  TimelineConfig,
+} from './timeline.types';
+
+/**
+ * Filters applied when baking a branch into the artifact.
+ *
+ * Mirrors the in-app timeline filters so the exported file matches what the
+ * user currently sees. Empty/undefined fields mean "no filtering".
+ */
+export interface ExportFilters {
+  /** Filter by exact item type ('' / undefined = all) */
+  type?: string;
+
+  /** Filter by project (partial, case-insensitive match; '' / undefined = all) */
+  project?: string;
+
+  /** Only include items ending on or after this ISO date */
+  startDate?: string;
+
+  /** Only include items starting on or before this ISO date */
+  endDate?: string;
+}
+
+/**
+ * A single branch's data to bake into the artifact.
+ *
+ * v1 callers pass exactly one branch, but the export payload is structured to
+ * hold many so that v2 (multi-scenario toggle) is purely additive.
+ */
+export interface ExportBranchInput {
+  /** Branch identifier */
+  branchId: string;
+
+  /** Human-readable branch label (falls back to branchId in the UI) */
+  label?: string | null;
+
+  /** Items belonging to this branch (already on the branch; pre-filter optional) */
+  items: Item[];
+}
+
+/**
+ * Options controlling artifact generation.
+ */
+export interface ExportOptions {
+  /** Branch rendered as the active/visible timeline */
+  activeBranchId: string;
+
+  /** Zoom level used for layout (defaults to 'month') */
+  zoomLevel?: ZoomLevel;
+
+  /** How to group items into swim lanes (defaults to 'lane') */
+  laneGroupBy?: LaneGroupBy;
+
+  /** Filters applied to every branch before rendering */
+  filters?: ExportFilters;
+
+  /** Title shown in the artifact header (defaults to a generated title) */
+  title?: string;
+
+  /** Generation timestamp (defaults to `new Date()`) */
+  generatedAt?: Date;
+}
+
+/**
+ * Pure, serializable render model for one branch.
+ *
+ * This is the view model the exporter computes from the timeline service. It is
+ * also embedded (as JSON) in the artifact so future versions can re-render
+ * client-side without recomputation.
+ */
+export interface ExportRenderModel {
+  /** Timeline layout configuration used to position items */
+  config: TimelineConfig;
+
+  /** Overall date range of the (filtered) items */
+  dateRange: DateRange;
+
+  /** Swim lanes with their items and computed heights */
+  laneGroups: LaneGroup[];
+
+  /** Time axis tick marks */
+  timeAxisTicks: TimeAxisTick[];
+
+  /** Total SVG width in pixels */
+  svgWidth: number;
+
+  /** Total SVG height in pixels */
+  svgHeight: number;
+}
+
+/**
+ * The full payload embedded in the artifact as inlined JSON.
+ *
+ * v1 populates `branches` with a single entry; the shape supports N branches.
+ */
+export interface ExportPayload {
+  /** Artifact format version (bump when the embedded shape changes) */
+  formatVersion: number;
+
+  /** Display title */
+  title: string;
+
+  /** ISO timestamp of generation */
+  generatedAt: string;
+
+  /** Zoom level used for layout */
+  zoomLevel: ZoomLevel;
+
+  /** Lane grouping strategy used */
+  laneGroupBy: LaneGroupBy;
+
+  /** Filters applied before rendering */
+  filters: ExportFilters;
+
+  /** Branch id rendered as active */
+  activeBranchId: string;
+
+  /** All baked branches (v1: one) */
+  branches: ExportPayloadBranch[];
+}
+
+/**
+ * One branch entry inside {@link ExportPayload}.
+ */
+export interface ExportPayloadBranch {
+  branchId: string;
+  label: string | null;
+  items: Item[];
+}

--- a/src/types/export.types.ts
+++ b/src/types/export.types.ts
@@ -60,8 +60,14 @@ export interface ExportOptions {
   /** Branch rendered as the active/visible timeline */
   activeBranchId: string;
 
-  /** Zoom level used for layout (defaults to 'month') */
+  /** Initial/active zoom level used for layout (defaults to 'month') */
   zoomLevel?: ZoomLevel;
+
+  /**
+   * Zoom levels to bake in so the reader can switch zoom inside the artifact.
+   * The active `zoomLevel` is always included. Defaults to a sensible set.
+   */
+  zoomLevels?: ZoomLevel[];
 
   /** How to group items into swim lanes (defaults to 'lane') */
   laneGroupBy?: LaneGroupBy;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -54,6 +54,16 @@ export type {
   TimelineInteraction,
 } from './timeline.types';
 
+// HTML artifact export types
+export type {
+  ExportFilters,
+  ExportBranchInput,
+  ExportOptions,
+  ExportRenderModel,
+  ExportPayload,
+  ExportPayloadBranch,
+} from './export.types';
+
 // Branch comparison types
 export type {
   ComparisonStatus,

--- a/src/utils/download.utils.test.ts
+++ b/src/utils/download.utils.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for browser download utilities.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { buildArtifactFilename, downloadTextFile } from './download.utils';
+
+describe('download.utils', () => {
+  describe('buildArtifactFilename', () => {
+    it('slugifies the label and appends the ISO date and extension', () => {
+      const name = buildArtifactFilename('Main Plan', new Date('2026-06-25T12:00:00Z'));
+      expect(name).toBe('swimlanes-main-plan-2026-06-25.html');
+    });
+
+    it('collapses runs of non-alphanumerics and trims edge dashes', () => {
+      const name = buildArtifactFilename('  Q1 // Stretch!! ', new Date('2026-01-02T00:00:00Z'));
+      expect(name).toBe('swimlanes-q1-stretch-2026-01-02.html');
+    });
+
+    it('falls back to "timeline" when the label has no usable characters', () => {
+      const name = buildArtifactFilename('!!!', new Date('2026-01-02T00:00:00Z'));
+      expect(name).toBe('swimlanes-timeline-2026-01-02.html');
+    });
+
+    it('honors a custom extension', () => {
+      const name = buildArtifactFilename('main', new Date('2026-01-02T00:00:00Z'), 'svg');
+      expect(name.endsWith('.svg')).toBe(true);
+    });
+  });
+
+  describe('downloadTextFile', () => {
+    beforeEach(() => {
+      // jsdom lacks object URL APIs; stub them.
+      (URL as unknown as { createObjectURL: () => string }).createObjectURL = vi.fn(
+        () => 'blob:mock'
+      );
+      (URL as unknown as { revokeObjectURL: () => void }).revokeObjectURL = vi.fn();
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('creates an anchor, clicks it, and revokes the object URL', () => {
+      const clickSpy = vi.fn();
+      const realCreate = document.createElement.bind(document);
+      const createSpy = vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+        const el = realCreate(tag);
+        if (tag === 'a') el.click = clickSpy;
+        return el;
+      });
+
+      downloadTextFile('test.html', '<html></html>');
+
+      expect(URL.createObjectURL).toHaveBeenCalledOnce();
+      expect(clickSpy).toHaveBeenCalledOnce();
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock');
+
+      createSpy.mockRestore();
+    });
+  });
+});

--- a/src/utils/download.utils.ts
+++ b/src/utils/download.utils.ts
@@ -1,0 +1,56 @@
+/**
+ * Browser download utilities.
+ */
+
+/**
+ * Builds a safe, descriptive filename for an exported artifact.
+ *
+ * @param label - Branch label or name to include in the filename
+ * @param date - Generation date (defaults to now)
+ * @param extension - File extension without the dot (defaults to 'html')
+ * @returns A slugified filename, e.g. `swimlanes-main-plan-2026-06-25.html`
+ *
+ * @example
+ * buildArtifactFilename('Main Plan') // 'swimlanes-main-plan-2026-06-25.html'
+ */
+export function buildArtifactFilename(
+  label: string,
+  date: Date = new Date(),
+  extension = 'html'
+): string {
+  const slug =
+    label
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 60) || 'timeline';
+
+  const iso = date.toISOString().split('T')[0];
+  return `swimlanes-${slug}-${iso}.${extension}`;
+}
+
+/**
+ * Triggers a browser download of a text payload as a file.
+ *
+ * Uses an object URL + temporary anchor; the URL is revoked afterwards to avoid
+ * leaks. No-op outside a browser environment (no `document`).
+ *
+ * @param filename - Suggested filename for the download
+ * @param content - File contents
+ * @param mimeType - MIME type (defaults to 'text/html')
+ */
+export function downloadTextFile(filename: string, content: string, mimeType = 'text/html'): void {
+  if (typeof document === 'undefined') return;
+
+  const blob = new Blob([content], { type: `${mimeType};charset=utf-8` });
+  const url = URL.createObjectURL(blob);
+
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary

Adds a standalone, **self-contained HTML timeline artifact** as a first-class output of SwimLanes — conceptually Plotly's `fig.write_html()`, but purpose-built for swim-lane timelines and hand-rolled in SVG. The exported file opens in any browser, **offline**, with the dataset inlined as JSON and a tiny embedded renderer — no app, server, `sql.js`, or React runtime.

Positioning (see `ref/html-artifact-export.md`): the React app stays the scenario-authoring tool; this HTML report is the flagship, shareable output. The exporter is a *consumer* of `timeline.service.ts`, so the artifact matches the in-app rendering.

## What's included

**Export pipeline**
- `services/export.service.ts` — builds a serializable view model and emits the self-contained HTML (`generateTimelineArtifact`)
- `types/export.types.ts` — export options/payload types (wired into the barrel)
- `utils/download.utils.ts` — slugified/dated filename + browser download helper
- `components/export/ExportPanel.tsx` + an **Export** tab — pick branch(es), zoom, grouping, optional filters/title; downloads the artifact

**Artifact features**
- Visual encoding matches the app: task=blue bar, milestone=green diamond, release=orange, meeting=purple; alternating lane backgrounds; time axis; hover tooltips
- **Multi-scenario toggle** — bake N branches into one file and switch between them offline
- **Frozen 2D panes** — the date axis stays pinned at the top and the lane labels at the left during scroll (corner anchored)
- **In-artifact zoom switcher** — week/month/quarter/year (configurable) re-scale without re-exporting
- **Dependency arrows**, light/dark **theme toggle**, **Today** marker, **period shading bands** (weekends at day zoom; alternating month/quarter/year otherwise), **lane item-count badges**, **print/PDF** layout, legend + metadata header
- Read-only; output-safe escaping (XML + `</script>` neutralization)

## Issues

Implements #61, #62, #63, #64. The optional read-only branch **diff view** was split out to #65 (not included here).

## Testing

- Unit tests for the exporter, download utils, and the Export panel; existing App/TabNavigation suites updated for the new tab
- `npm run typecheck`, ESLint, and `npm run build` all pass
- Browser-verified with Playwright: multi-scenario toggle, 2D pane freeze, zoom switch, dependency arrows, dark theme, period bands, lane counts

## Note

Live in-app end-to-end verification is limited in sandboxes that block the `sql.js` CDN (the app fails to boot — see #53). The export pipeline here is covered by unit/integration tests plus generated artifacts rendered in a headless browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lzh8239jRmEJCTuebshrk6)_